### PR TITLE
Fix drag/drop, metric conversions, and collision detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,9 +60,9 @@
                 <div id="grid-controls-bar" class="ui-bar">
                     <label>Сетка:
                         <select id="gridStep">
-                            <option value="25">0.5 м</option>
-                            <option value="50" selected>1 м</option>
-                            <option value="100">2 м</option>
+                            <option value="25" data-meters="0.5">0.5 м</option>
+                            <option value="50" data-meters="1" selected>1 м</option>
+                            <option value="100" data-meters="2">2 м</option>
                         </select>
                     </label>
                     <label><input type="checkbox" id="snapGuides" checked> Направляющие</label>


### PR DESCRIPTION
## Summary
- emulate InteractJS dropzone events in the local stub so palette items and trash drops work again
- track a pixels-per-meter ratio when the grid changes to keep measurement and analysis numbers in meters
- base collision boxes on rotated geometry (with a getBBox fast path) to flag overlaps reliably
- allow panning the canvas by dragging the background with the primary mouse button, initializing the viewBox lazily when needed

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cd07635c4483338c31e63c34e7436c