### PR TITLE
Align SVG layers with specification

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,9 +4,9 @@
     const LOCAL_STORAGE_KEY = 'layout-v10-pro'; // Incremented version to avoid loading old potentially corrupt data
     const dom = {
         svg: document.getElementById('svg'),
-        itemsContainer: document.getElementById('items'),
-        wallsContainer: document.getElementById('walls'),
-        wallComponentsContainer: document.getElementById('wall-components'),
+        itemsContainer: document.getElementById('items-layer'),
+        wallsContainer: document.getElementById('walls-layer'),
+        wallComponentsContainer: document.getElementById('openings-layer'),
         previewsContainer: document.getElementById('previews'),
         sidebar: document.getElementById('sidebar'),
         properties: document.getElementById('properties'),
@@ -41,7 +41,7 @@
         wallPreview: document.getElementById('wall-preview'),
         toggleSidebar: document.getElementById('toggle-sidebar'),
         toggleProperties: document.getElementById('toggle-properties'),
-        measurementLayer: document.getElementById('measurement'),
+        measurementLayer: document.getElementById('measurement-layer'),
         // слой для результатов анализа
         analysisLayer: document.getElementById('analysis-layer'),
         // контекстное меню: фокусировка на объекте

--- a/index.html
+++ b/index.html
@@ -85,18 +85,22 @@
                         </pattern>
                     </defs>
                     <rect width="100%" height="100%" class="floor"/>
-                    <rect id="gridRect" width="100%" height="100%" fill="url(#grid)" opacity="0.7"/>
-                    
-                    <g id="walls"></g>
-                    <g id="wall-components"></g>
-                    <polyline id="wall-preview" fill="none" stroke="var(--accent)" stroke-width="5" stroke-dasharray="10 5" pointer-events="none" />
-                    
-                    <g id="items"></g>
-                    <g id="previews"></g>
+                    <g id="grid-layer" pointer-events="none">
+                        <rect width="100%" height="100%" fill="url(#grid)" opacity="0.7"/>
+                    </g>
+                    <g id="underlay-layer"></g>
+                    <g id="walls-layer"></g>
+                    <g id="openings-layer"></g>
+                    <g id="items-layer"></g>
+                    <g id="preview-layer" pointer-events="none">
+                        <polyline id="wall-preview" fill="none" stroke="var(--accent)" stroke-width="5" stroke-dasharray="10 5" pointer-events="none" />
+                        <g id="previews"></g>
+                    </g>
                     <!-- Слой для отображения результатов анализа (помещения, зоны, коллизии) -->
-                    <g id="analysis-layer"></g>
+                    <g id="analysis-layer" pointer-events="none"></g>
                     <!-- Слой для отображения измерительных линий и аннотаций. Размещаем ПОСЛЕ слоя анализа, чтобы линии и подписи были видны поверх зон. -->
-                    <g id="measurement"></g>
+                    <g id="measurement-layer" pointer-events="none"></g>
+                    <g id="ui-layer" pointer-events="none"></g>
                 </svg>
                 <div id="toast" aria-live="polite"></div>
             </div>

--- a/style.css
+++ b/style.css
@@ -41,16 +41,21 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--text);font-famil
 }
 svg{width:100%;height:100%}
 svg.tool-active { cursor: crosshair; }
-.wall,.inner-wall,.win,.col,.door-arc,.dim-line, #walls path {vector-effect:non-scaling-stroke}
-#walls path { fill:none;stroke:#343a40;stroke-width:11;stroke-linejoin:round;stroke-linecap:round; cursor: pointer; }
-#walls path.selected { stroke: var(--accent); }
+.wall,.inner-wall,.win,.col,.door-arc,.dim-line, #walls-layer path {vector-effect:non-scaling-stroke}
+#walls-layer path { fill:none;stroke:#343a40;stroke-width:11;stroke-linejoin:round;stroke-linecap:round; cursor: pointer; }
+#walls-layer path.selected { stroke: var(--accent); }
 .wall-component { cursor: pointer; }
 .wall-component.selected > * { stroke: var(--accent) !important; stroke-width: 3; vector-effect: non-scaling-stroke; }
 .floor{fill:#fdfdfd;}
-#gridRect{pointer-events:none}
+#grid-layer{pointer-events:none}
+
+#preview-layer,
+#analysis-layer,
+#measurement-layer,
+#ui-layer{pointer-events:none}
 
 /* --- Measurement Layer --- */
-#measurement line {
+#measurement-layer line {
   vector-effect: non-scaling-stroke;
   stroke: var(--accent);
   /* Толще, чтобы линия была лучше видна */
@@ -58,7 +63,7 @@ svg.tool-active { cursor: crosshair; }
   marker-start: url(#dim-arrow);
   marker-end: url(#dim-arrow);
 }
-#measurement text {
+#measurement-layer text {
   font-size: 14px;
   font-weight: bold;
   fill: var(--accent);
@@ -69,7 +74,7 @@ svg.tool-active { cursor: crosshair; }
 }
 
 /* Слой измерений не должен перехватывать события мыши, иначе клики перестанут работать */
-#measurement {
+#measurement-layer {
   pointer-events: none;
 }
 
@@ -192,8 +197,8 @@ svg.tool-active { cursor: crosshair; }
 .wall-handles circle{fill:var(--accent);stroke:#fff;stroke-width:2;pointer-events:all;cursor:pointer}
 .wall-handles circle.active{fill:var(--danger)}
 .wall-segment-insert{fill:#fff;stroke:var(--accent);stroke-dasharray:2 2;pointer-events:all;cursor:crosshair;opacity:.7}
-#walls .wall.selected .wall-handles,#walls .wall.selected .wall-segment-insert{display:block}
-#walls .wall .wall-handles,#walls .wall .wall-segment-insert{display:none}
+#walls-layer .wall.selected .wall-handles,#walls-layer .wall.selected .wall-segment-insert{display:block}
+#walls-layer .wall .wall-handles,#walls-layer .wall .wall-segment-insert{display:none}
 .status-ok{color:#2b8a3e;font-weight:600}
 .status-warn{color:var(--danger);font-weight:600}
 


### PR DESCRIPTION
## Summary
- restructure the SVG scene graph to provide dedicated grid, underlay, walls, openings, preview, measurement, analysis, and UI layers matching the specification
- update the application bootstrap code so wall, opening, preview, and measurement logic address the renamed layers
- adjust styles to target the new layer ids and ensure overlay groups don’t intercept pointer events

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd1aa5022083339c64aa63756ae174