### PR TITLE
Add wall type palette and wall length preview

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,9 +4,9 @@
     const LOCAL_STORAGE_KEY = 'layout-v10-pro'; // Incremented version to avoid loading old potentially corrupt data
     const dom = {
         svg: document.getElementById('svg'),
-        itemsContainer: document.getElementById('items'),
-        wallsContainer: document.getElementById('walls'),
-        wallComponentsContainer: document.getElementById('wall-components'),
+        itemsContainer: document.getElementById('items-layer'),
+        wallsContainer: document.getElementById('walls-layer'),
+        wallComponentsContainer: document.getElementById('openings-layer'),
         previewsContainer: document.getElementById('previews'),
         sidebar: document.getElementById('sidebar'),
         properties: document.getElementById('properties'),
@@ -24,6 +24,9 @@
         propW: document.getElementById('prop-w'),
         propH: document.getElementById('prop-h'),
         propA: document.getElementById('prop-a'),
+        wallTypePanel: document.getElementById('wall-properties'),
+        wallTypeOptions: document.getElementById('wall-type-options'),
+        wallTypeCaption: document.getElementById('wall-type-caption'),
         btnExport: document.getElementById('btnExport'),
         btnImport: document.getElementById('btnImport'),
         fileImport: document.getElementById('fileImport'),
@@ -41,9 +44,10 @@
         wallPreview: document.getElementById('wall-preview'),
         toggleSidebar: document.getElementById('toggle-sidebar'),
         toggleProperties: document.getElementById('toggle-properties'),
-        measurementLayer: document.getElementById('measurement'),
+        measurementLayer: document.getElementById('measurement-layer'),
         // слой для результатов анализа
         analysisLayer: document.getElementById('analysis-layer'),
+        wallLengthLabel: document.getElementById('wall-length-label'),
         // контекстное меню: фокусировка на объекте
         ctxFocus: document.getElementById('ctx-focus'),
         measureTableBody: document.getElementById('measure-table-body'),
@@ -70,6 +74,7 @@
         history: { stack: [], idx: -1, lock: false },
         activeTool: 'pointer',
         currentWallPoints: [],
+        defaultWallType: 'structural',
         // Хранилище для измерительного инструмента
         measurePoints: [],
         measurements: [],
@@ -100,6 +105,12 @@
     const wallIdMap = new Map();
     const componentStore = new Map();
     const componentIdMap = new Map();
+    const WALL_TYPES = [
+        { id: 'structural', label: 'Капитальная', description: 'Несущая стена, толщина ~250 мм' },
+        { id: 'partition', label: 'Перегородка', description: 'Лёгкая перегородка, толщина ~100 мм' },
+        { id: 'glass', label: 'Стеклянная', description: 'Витраж или стеклянная перегородка' },
+        { id: 'half', label: 'Полустена', description: 'Парапет, барная стойка или ограждение' }
+    ];
     const ESTIMATE_PRESETS = {
         standard: { finish: 50, perimeter: 12, engineering: 35 },
         economy: { finish: 35, perimeter: 8, engineering: 20 },
@@ -169,6 +180,122 @@
         return { x: cx * factor, y: cy * factor };
     }
 
+    // --- WALL TYPE HELPERS & UI ---
+    function ensureWallType(value) {
+        if (typeof value === 'string') {
+            const trimmed = value.trim().toLowerCase();
+            const direct = WALL_TYPES.find(t => t.id === trimmed);
+            if (direct) return direct.id;
+            if (trimmed.includes('капит')) return 'structural';
+            if (trimmed.includes('перегор') || trimmed.includes('partition')) return 'partition';
+            if (trimmed.includes('glass') || trimmed.includes('стек')) return 'glass';
+            if (trimmed.includes('half') || trimmed.includes('парап') || trimmed.includes('бар')) return 'half';
+        }
+        return WALL_TYPES[0].id;
+    }
+
+    function getWallTypeMeta(id) {
+        const resolved = ensureWallType(id);
+        return WALL_TYPES.find(t => t.id === resolved) || WALL_TYPES[0];
+    }
+
+    function highlightWallType(typeId) {
+        if (!dom.wallTypeOptions) return;
+        const resolved = ensureWallType(typeId);
+        dom.wallTypeOptions.querySelectorAll('button[data-type]').forEach(btn => {
+            const isActive = btn.dataset.type === resolved;
+            btn.classList.toggle('active', isActive);
+            btn.setAttribute('aria-checked', isActive ? 'true' : 'false');
+        });
+    }
+
+    function updateWallTypeCaption(mode = 'default', typeId = state.defaultWallType) {
+        if (!dom.wallTypeCaption) return;
+        const meta = getWallTypeMeta(typeId);
+        const prefix = mode === 'selected' ? 'Выбранная стена:' : 'Новые стены:';
+        dom.wallTypeCaption.textContent = `${prefix} ${meta.label}`;
+    }
+
+    function initWallTypeOptions() {
+        if (!dom.wallTypeOptions) return;
+        dom.wallTypeOptions.innerHTML = '';
+        WALL_TYPES.forEach(type => {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'wall-type-option';
+            btn.dataset.type = type.id;
+            btn.setAttribute('role', 'radio');
+            btn.setAttribute('aria-checked', 'false');
+            btn.title = type.description;
+            btn.innerHTML = `<svg viewBox="0 0 48 18" aria-hidden="true" focusable="false"><line x1="4" y1="9" x2="44" y2="9"></line></svg><span>${type.label}</span>`;
+            dom.wallTypeOptions.appendChild(btn);
+        });
+        dom.wallTypeOptions.addEventListener('click', e => {
+            const btn = e.target.closest('button[data-type]');
+            if (!btn) return;
+            handleWallTypeOptionClick(btn.dataset.type);
+        });
+        dom.wallTypeOptions.addEventListener('keydown', e => {
+            const btn = e.target.closest('button[data-type]');
+            if (!btn) return;
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handleWallTypeOptionClick(btn.dataset.type);
+            }
+        });
+    }
+
+    function handleWallTypeOptionClick(typeId) {
+        const resolved = ensureWallType(typeId);
+        state.defaultWallType = resolved;
+        highlightWallType(resolved);
+        if (state.selectedWall) {
+            const model = getWallModel(state.selectedWall);
+            if (model) {
+                if (model.type !== resolved) {
+                    model.type = resolved;
+                    state.selectedWall.dataset.type = resolved;
+                    updateWallElementGeometry(state.selectedWall);
+                    commit('wall_type');
+                }
+                updateWallTypeCaption('selected', resolved);
+            }
+        } else {
+            updateWallTypeCaption('default', resolved);
+            const meta = getWallTypeMeta(resolved);
+            utils.showToast(`Тип стен по умолчанию: ${meta.label}`);
+        }
+    }
+
+    // --- WALL LENGTH PREVIEW ---
+    function hideWallLengthPreview() {
+        if (!dom.wallLengthLabel) return;
+        dom.wallLengthLabel.setAttribute('visibility', 'hidden');
+        dom.wallLengthLabel.removeAttribute('transform');
+    }
+
+    function updateWallLengthPreview(a, b) {
+        if (!dom.wallLengthLabel || !a || !b) return;
+        const midX = (a.x + b.x) / 2;
+        const midY = (a.y + b.y) / 2;
+        const dx = b.x - a.x;
+        const dy = b.y - a.y;
+        const len = Math.sqrt(dx * dx + dy * dy);
+        if (len < 0.5) {
+            hideWallLengthPreview();
+            return;
+        }
+        const pxPerMeter = state.pixelsPerMeter || state.gridSize || 1;
+        const meters = pxPerMeter ? len / pxPerMeter : len;
+        const angleRaw = Math.atan2(dy, dx) * 180 / Math.PI;
+        const angle = angleRaw > 90 || angleRaw < -90 ? angleRaw + 180 : angleRaw;
+        dom.wallLengthLabel.textContent = `${meters.toFixed(2)} м`;
+        dom.wallLengthLabel.setAttribute('x', midX);
+        dom.wallLengthLabel.setAttribute('y', midY);
+        dom.wallLengthLabel.setAttribute('transform', `rotate(${angle} ${midX} ${midY})`);
+        dom.wallLengthLabel.setAttribute('visibility', 'visible');
+    }
+
     // --- DATA & MODEL ---
     function getModel(el) { if (!el || !el.dataset) return {}; return { id: el.dataset.id, tpl: el.dataset.template || 'zone', x: +el.dataset.x || 0, y: +el.dataset.y || 0, a: +el.dataset.a || 0, sx: +el.dataset.sx || 1, sy: +el.dataset.sy || 1, cx: +el.dataset.cx || 0, cy: +el.dataset.cy || 0, ow: +el.dataset.ow || 0, oh: +el.dataset.oh || 0, locked: el.dataset.locked === 'true', visible: el.dataset.visible !== 'false' }; }
     function setModel(el, model) { for (const k in model) { if (model[k] !== undefined) el.dataset[k] = model[k]; } applyTransformFromDataset(el); updatePropertiesPanel(model); updateLayerItem(model); }
@@ -187,6 +314,8 @@
         state.selectedWallHandle = null;
         dom.layersList.querySelector('.selected')?.classList.remove('selected');
         updatePropertiesPanel(null);
+        highlightWallType(state.defaultWallType);
+        updateWallTypeCaption('default', state.defaultWallType);
     }
 
     /**
@@ -244,6 +373,15 @@
         clearSelections();
         state.selectedWall = wall;
         state.selectedWall.classList.add('selected');
+        const model = getWallModel(wall);
+        if (model) {
+            const resolved = ensureWallType(model.type || state.defaultWallType);
+            model.type = resolved;
+            wall.dataset.type = resolved;
+            state.defaultWallType = resolved;
+            highlightWallType(resolved);
+            updateWallTypeCaption('selected', resolved);
+        }
         updateWallHandles(wall);
     }
     function selectComponent(compEl) { if (state.activeTool !== 'pointer') return; clearSelections(); state.selectedComponent = compEl; if (state.selectedComponent) { state.selectedComponent.classList.add('selected'); } }
@@ -399,6 +537,9 @@
     function updateWallElementGeometry(wallEl) {
         const model = getWallModel(wallEl);
         if (!model) return;
+        const resolvedType = ensureWallType(model.type || state.defaultWallType);
+        model.type = resolvedType;
+        wallEl.dataset.type = resolvedType;
         const path = wallEl.querySelector('path') || document.createElementNS('http://www.w3.org/2000/svg', 'path');
         if (!path.parentNode) wallEl.appendChild(path);
         const pts = model.points;
@@ -422,9 +563,11 @@
         wallEl.classList.add('wall');
         const id = `wall-${++state.wallCounter}`;
         wallEl.dataset.id = id;
-        const model = { id, points: points.map(p => ({ x: p.x, y: p.y })), closed, components: [] };
+        const type = ensureWallType(state.defaultWallType);
+        const model = { id, points: points.map(p => ({ x: p.x, y: p.y })), closed, components: [], type };
         const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
         wallEl.appendChild(path);
+        wallEl.dataset.type = type;
         dom.wallsContainer.appendChild(wallEl);
         registerWall(wallEl, model);
         return wallEl;
@@ -592,6 +735,7 @@
         dom.wallPreview.setAttribute('points', '');
         dom.previewsContainer.innerHTML = '';
         state.pendingComponentPlacement = null;
+        hideWallLengthPreview();
         // Покидая режим измерения — сохраняем линии, но убираем предпросмотр
         if (state.activeTool !== 'measure') {
             resetMeasurementPreview();
@@ -618,6 +762,7 @@
         }
         state.currentWallPoints = [];
         dom.wallPreview.setAttribute('points', '');
+        hideWallLengthPreview();
     }
     function placeWallComponent(type, placement) {
         const wallEl = ensureWallElement(placement?.wallEl || (state.pendingComponentPlacement?.wallEl));
@@ -1251,7 +1396,8 @@
             walls: Array.from(wallStore.values()).map(model => ({
                 id: model.id,
                 points: model.points.map(p => ({ x: p.x, y: p.y })),
-                closed: model.closed
+                closed: model.closed,
+                type: ensureWallType(model.type || state.defaultWallType)
             })),
             components: Array.from(componentStore.values()).map(comp => ({
                 id: comp.id,
@@ -1260,6 +1406,7 @@
                 distance: comp.distance,
                 offset: comp.offset || 0
             })),
+            wallDefaults: { type: state.defaultWallType },
             measurements: state.measurements.map(m => ({ ...m })),
             normatives: {
                 corridorGuest: state.normativeCorridorGuest,
@@ -1292,6 +1439,11 @@
         componentIdMap.clear();
         state.componentCounter = 0;
         state.pendingComponentPlacement = null;
+
+        state.defaultWallType = ensureWallType(data?.wallDefaults?.type || state.defaultWallType);
+        highlightWallType(state.defaultWallType);
+        updateWallTypeCaption('default', state.defaultWallType);
+        hideWallLengthPreview();
 
         (data.items || []).forEach(m => {
             const el = createLayoutObject(m.tpl, m.x, m.y);
@@ -1363,6 +1515,9 @@
                 model.id = w.id;
                 wallEl.dataset.id = w.id;
             }
+            const resolvedType = ensureWallType(wallData?.type || wallData?.material || model.type);
+            model.type = resolvedType;
+            wallEl.dataset.type = resolvedType;
             model.closed = !!wallData.closed;
             model.components = [];
             wallStore.set(wallEl, model);
@@ -1676,14 +1831,21 @@
         dom.svg.addEventListener('mousemove', utils.rafThrottle(e => {
             const tool = state.activeTool;
             const p = utils.toSVGPoint(e.clientX, e.clientY);
-            // Обновление превью стены
-            if (tool === 'wall' && state.currentWallPoints.length > 0) {
-                const snappedP = { x: snap(p.x), y: snap(p.y) };
-                const pointsAttr = [...state.currentWallPoints, snappedP].map(pt => `${pt.x},${pt.y}`).join(' ');
-                dom.wallPreview.setAttribute('points', pointsAttr);
+            // Обновление превью стены и длины сегмента
+            if (tool === 'wall') {
+                if (state.currentWallPoints.length > 0) {
+                    const snappedP = { x: snap(p.x), y: snap(p.y) };
+                    const pointsAttr = [...state.currentWallPoints, snappedP].map(pt => `${pt.x},${pt.y}`).join(' ');
+                    dom.wallPreview.setAttribute('points', pointsAttr);
+                    const lastPoint = state.currentWallPoints[state.currentWallPoints.length - 1];
+                    updateWallLengthPreview(lastPoint, snappedP);
+                } else {
+                    hideWallLengthPreview();
+                }
             }
             // Превью дверей/окон
             else if (tool === 'door' || tool === 'window') {
+                hideWallLengthPreview();
                 dom.previewsContainer.innerHTML = '';
                 state.pendingComponentPlacement = null;
                 const closest = findClosestWallPlacement(p);
@@ -1700,6 +1862,7 @@
             }
             // Динамическое измерение: если одна точка выбрана, рисуем линию к курсору
             else if (tool === 'measure' && state.measurePoints.length === 1) {
+                hideWallLengthPreview();
                 const p0 = state.measurePoints[0];
                 const preview = {
                     p0,
@@ -1708,8 +1871,11 @@
                     angle: (Math.atan2(p.y - p0.y, p.x - p0.x) * 180 / Math.PI + 360) % 360
                 };
                 renderMeasurementOverlay(preview);
+            } else {
+                hideWallLengthPreview();
             }
         }));
+        dom.svg.addEventListener('mouseleave', hideWallLengthPreview);
         // Контекстное меню открывается только в режиме указателя. По ПКМ выбираем объект и отображаем меню.
         dom.svg.addEventListener('contextmenu', e => {
             e.preventDefault();
@@ -1820,6 +1986,11 @@
             });
         });
         dom.sidebar.insertBefore(fragment, dom.layersPanel);
+
+        initWallTypeOptions();
+        highlightWallType(state.defaultWallType);
+        updateWallTypeCaption('default', state.defaultWallType);
+        hideWallLengthPreview();
 
         // Setup interact.js
         interact('.draggable-item').draggable({ inertia: true, autoScroll: true, listeners: { start(e) { const g = e.target.cloneNode(true); Object.assign(g.style, { position: 'absolute', opacity: .7, pointerEvents: 'none', zIndex: 1000 }); document.body.appendChild(g); e.interaction.ghost = g; }, move(e) { const g = e.interaction.ghost; if (!g) return; g.style.left = `${e.clientX - e.rect.width / 2}px`; g.style.top = `${e.clientY - e.rect.height / 2}px`; }, end(e) { e.interaction.ghost?.remove(); } } });

--- a/index.html
+++ b/index.html
@@ -85,18 +85,23 @@
                         </pattern>
                     </defs>
                     <rect width="100%" height="100%" class="floor"/>
-                    <rect id="gridRect" width="100%" height="100%" fill="url(#grid)" opacity="0.7"/>
-                    
-                    <g id="walls"></g>
-                    <g id="wall-components"></g>
-                    <polyline id="wall-preview" fill="none" stroke="var(--accent)" stroke-width="5" stroke-dasharray="10 5" pointer-events="none" />
-                    
-                    <g id="items"></g>
-                    <g id="previews"></g>
+                    <g id="grid-layer" pointer-events="none">
+                        <rect width="100%" height="100%" fill="url(#grid)" opacity="0.7"/>
+                    </g>
+                    <g id="underlay-layer"></g>
+                    <g id="walls-layer"></g>
+                    <g id="openings-layer"></g>
+                    <g id="items-layer"></g>
+                    <g id="preview-layer" pointer-events="none">
+                        <polyline id="wall-preview" fill="none" stroke="var(--accent)" stroke-width="5" stroke-dasharray="10 5" pointer-events="none" />
+                        <g id="previews"></g>
+                        <text id="wall-length-label" class="wall-length-label" text-anchor="middle" dominant-baseline="middle" visibility="hidden">0.00 м</text>
+                    </g>
                     <!-- Слой для отображения результатов анализа (помещения, зоны, коллизии) -->
-                    <g id="analysis-layer"></g>
+                    <g id="analysis-layer" pointer-events="none"></g>
                     <!-- Слой для отображения измерительных линий и аннотаций. Размещаем ПОСЛЕ слоя анализа, чтобы линии и подписи были видны поверх зон. -->
-                    <g id="measurement"></g>
+                    <g id="measurement-layer" pointer-events="none"></g>
+                    <g id="ui-layer" pointer-events="none"></g>
                 </svg>
                 <div id="toast" aria-live="polite"></div>
             </div>
@@ -112,6 +117,14 @@
                 <label class="prop-label">Высота:</label><input type="number" id="prop-h" step="10" min="1">
                 <label class="prop-label">Поворот:</label><input type="number" id="prop-a" step="15" min="-360" max="360">
             </div>
+
+            <section id="wall-properties" class="panel" aria-label="Параметры стен">
+                <div class="panel-header">
+                    <h3>Стены</h3>
+                </div>
+                <p id="wall-type-caption" class="wall-type-caption">Новые стены: Капитальная</p>
+                <div id="wall-type-options" class="wall-type-options" role="radiogroup" aria-label="Тип стены"></div>
+            </section>
 
             <section id="measurement-panel" class="panel" aria-label="Список измерений">
                 <div class="panel-header">

--- a/style.css
+++ b/style.css
@@ -41,16 +41,51 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--text);font-famil
 }
 svg{width:100%;height:100%}
 svg.tool-active { cursor: crosshair; }
-.wall,.inner-wall,.win,.col,.door-arc,.dim-line, #walls path {vector-effect:non-scaling-stroke}
-#walls path { fill:none;stroke:#343a40;stroke-width:11;stroke-linejoin:round;stroke-linecap:round; cursor: pointer; }
-#walls path.selected { stroke: var(--accent); }
+.wall,.inner-wall,.win,.col,.door-arc,.dim-line, #walls-layer path {vector-effect:non-scaling-stroke}
+#walls-layer .wall path {
+  fill: none;
+  cursor: pointer;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+  transition: stroke .2s ease, stroke-width .2s ease, stroke-dasharray .2s ease;
+}
+#walls-layer .wall[data-type="structural"] path {
+  stroke: #343a40;
+  stroke-width: 16;
+}
+#walls-layer .wall[data-type="partition"] path {
+  stroke: #868e96;
+  stroke-width: 10;
+  stroke-dasharray: 28 12;
+  stroke-linecap: butt;
+}
+#walls-layer .wall[data-type="glass"] path {
+  stroke: rgba(77,171,247,.9);
+  stroke-width: 8;
+  stroke-dasharray: 12 8;
+  stroke-linecap: butt;
+}
+#walls-layer .wall[data-type="half"] path {
+  stroke: #adb5bd;
+  stroke-width: 8;
+  stroke-dasharray: 6 8;
+  stroke-linecap: butt;
+}
+#walls-layer .wall.selected path {
+  filter: drop-shadow(0 0 6px rgba(0,102,204,.6));
+}
 .wall-component { cursor: pointer; }
 .wall-component.selected > * { stroke: var(--accent) !important; stroke-width: 3; vector-effect: non-scaling-stroke; }
 .floor{fill:#fdfdfd;}
-#gridRect{pointer-events:none}
+#grid-layer{pointer-events:none}
+
+#preview-layer,
+#analysis-layer,
+#measurement-layer,
+#ui-layer{pointer-events:none}
 
 /* --- Measurement Layer --- */
-#measurement line {
+#measurement-layer line {
   vector-effect: non-scaling-stroke;
   stroke: var(--accent);
   /* Толще, чтобы линия была лучше видна */
@@ -58,7 +93,7 @@ svg.tool-active { cursor: crosshair; }
   marker-start: url(#dim-arrow);
   marker-end: url(#dim-arrow);
 }
-#measurement text {
+#measurement-layer text {
   font-size: 14px;
   font-weight: bold;
   fill: var(--accent);
@@ -69,7 +104,7 @@ svg.tool-active { cursor: crosshair; }
 }
 
 /* Слой измерений не должен перехватывать события мыши, иначе клики перестанут работать */
-#measurement {
+#measurement-layer {
   pointer-events: none;
 }
 
@@ -84,8 +119,28 @@ svg.tool-active { cursor: crosshair; }
 }
 
 /* --- Layout Objects --- */
-.layout-object{cursor:move; filter: url(#shadow);}
-.layout-object:hover { filter: url(#shadow) brightness(1.05); }
+.layout-object{cursor:move;}
+.layout-object .core{
+  filter:url(#shadow);
+  transition:filter .2s ease;
+}
+.layout-object:hover .core{filter:url(#shadow) brightness(1.08);}
+.layout-object.selected .core{filter:url(#shadow) brightness(1.12);}
+#items-layer .layout-object .core path,
+#items-layer .layout-object .core rect,
+#items-layer .layout-object .core circle,
+#items-layer .layout-object .core ellipse,
+#items-layer .layout-object .core polygon,
+#items-layer .layout-object .core polyline {
+  vector-effect:non-scaling-stroke;
+  stroke-linejoin:round;
+  stroke-linecap:round;
+}
+#items-layer .layout-object .core .shape {
+  paint-order:stroke fill;
+  stroke-width:1.2;
+  stroke:rgba(33,37,41,.18);
+}
 .layout-object.selected .selection-box{display:block}
 .selection-box{
   display:none;
@@ -167,6 +222,56 @@ svg.tool-active { cursor: crosshair; }
 
 #properties{gap:14px;}
 
+#wall-properties .panel-header h3{letter-spacing:.12em;}
+.wall-type-caption{
+  margin:0 0 6px;
+  font-size:11px;
+  letter-spacing:.1em;
+  text-transform:uppercase;
+  color:var(--muted);
+}
+.wall-type-options{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(140px,1fr));
+  gap:8px;
+}
+.wall-type-option{
+  display:flex;
+  align-items:center;
+  gap:10px;
+  border:1px solid var(--border);
+  border-radius:10px;
+  padding:10px 12px;
+  background:#fff;
+  cursor:pointer;
+  transition:border .2s ease, box-shadow .2s ease, background .2s ease;
+  font-size:13px;
+  color:var(--text);
+}
+.wall-type-option svg{width:48px;height:18px;overflow:visible;}
+.wall-type-option line{stroke-linecap:round;stroke-linejoin:round;}
+.wall-type-option[data-type="structural"] line{stroke:#343a40;stroke-width:12;}
+.wall-type-option[data-type="partition"] line{stroke:#868e96;stroke-width:9;stroke-dasharray:22 10;stroke-linecap:butt;}
+.wall-type-option[data-type="glass"] line{stroke:rgba(77,171,247,.9);stroke-width:7;stroke-dasharray:10 6;stroke-linecap:butt;}
+.wall-type-option[data-type="half"] line{stroke:#adb5bd;stroke-width:7;stroke-dasharray:5 7;stroke-linecap:butt;}
+.wall-type-option.active{
+  border-color:var(--accent);
+  box-shadow:0 0 0 2px rgba(0,102,204,.2);
+  background:rgba(0,102,204,.06);
+  color:var(--accent);
+}
+.wall-type-option:focus-visible{outline:2px solid var(--accent);}
+
+.wall-length-label{
+  font-size:18px;
+  font-weight:600;
+  fill:var(--text);
+  stroke:rgba(255,255,255,.92);
+  stroke-width:5;
+  paint-order:stroke fill;
+  pointer-events:none;
+}
+
 .panel{border:1px solid var(--border);border-radius:10px;padding:12px;background:var(--paper);display:flex;flex-direction:column;gap:10px;box-shadow:inset 0 1px 0 rgba(255,255,255,.6)}
 .panel-header{display:flex;align-items:center;justify-content:space-between;gap:8px}
 .panel-header h3{margin:0;font-size:14px;text-transform:uppercase;letter-spacing:.08em;color:var(--muted)}
@@ -192,8 +297,8 @@ svg.tool-active { cursor: crosshair; }
 .wall-handles circle{fill:var(--accent);stroke:#fff;stroke-width:2;pointer-events:all;cursor:pointer}
 .wall-handles circle.active{fill:var(--danger)}
 .wall-segment-insert{fill:#fff;stroke:var(--accent);stroke-dasharray:2 2;pointer-events:all;cursor:crosshair;opacity:.7}
-#walls .wall.selected .wall-handles,#walls .wall.selected .wall-segment-insert{display:block}
-#walls .wall .wall-handles,#walls .wall .wall-segment-insert{display:none}
+#walls-layer .wall.selected .wall-handles,#walls-layer .wall.selected .wall-segment-insert{display:block}
+#walls-layer .wall .wall-handles,#walls-layer .wall .wall-segment-insert{display:none}
 .status-ok{color:#2b8a3e;font-weight:600}
 .status-warn{color:var(--danger);font-weight:600}
 


### PR DESCRIPTION
## Summary
- add a wall-type palette with selectable presets, persist the chosen type on each wall, and style each variant distinctly in the SVG renderer
- render a live wall-segment length label while drawing to make wall placement easier to size precisely
- polish the furniture visuals with unified core styling and hover/selection treatments for all templates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd1aa5022083339c64aa63756ae174