### PR TITLE
feat: allow flexible grid step configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,12 +58,19 @@
                 </div>
                 
                 <div id="grid-controls-bar" class="ui-bar">
-                    <label>Сетка:
-                        <select id="gridStep">
-                            <option value="25" data-meters="0.5">0.5 м</option>
-                            <option value="50" data-meters="1" selected>1 м</option>
-                            <option value="100" data-meters="2">2 м</option>
-                        </select>
+                    <label class="grid-step-control">Сетка:
+                        <input id="gridStep" type="number" value="1" min="0.05" step="0.05" list="gridStepPresets" inputmode="decimal" aria-label="Шаг сетки, метры">
+                        <datalist id="gridStepPresets">
+                            <option value="0.25" label="0.25 м"></option>
+                            <option value="0.5" label="0.5 м"></option>
+                            <option value="0.75" label="0.75 м"></option>
+                            <option value="1" label="1 м"></option>
+                            <option value="1.5" label="1.5 м"></option>
+                            <option value="2" label="2 м"></option>
+                            <option value="3" label="3 м"></option>
+                            <option value="5" label="5 м"></option>
+                        </datalist>
+                        <span class="grid-step-unit">м</span>
                     </label>
                     <label><input type="checkbox" id="snapGuides" checked> Направляющие</label>
                 </div>

--- a/style.css
+++ b/style.css
@@ -197,8 +197,13 @@ svg.tool-active { cursor: crosshair; }
   background:#f6f7f8;
 }
 #grid-controls-bar{right:12px;top:12px;}
-#grid-controls-bar select{border:1px solid var(--border);background:#fff;border-radius:10px;padding:6px 10px;cursor:pointer}
 #grid-controls-bar label{display:flex;gap:6px;align-items:center}
+#grid-controls-bar .grid-step-control{gap:8px;white-space:nowrap}
+#grid-controls-bar input[type="number"]{border:1px solid var(--border);background:#fff;border-radius:10px;padding:6px 10px;width:88px;font-size:14px;line-height:1.3;}
+#grid-controls-bar input[type="number"]::-webkit-outer-spin-button,
+#grid-controls-bar input[type="number"]::-webkit-inner-spin-button{margin:0}
+#grid-controls-bar input[type="number"]{-moz-appearance:textfield}
+#grid-controls-bar .grid-step-unit{font-size:12px;color:var(--muted);}
 #toast{position:absolute;left:50%;top:20px;transform:translateX(-50%);background:#212529;color:#fff;padding:10px 16px;border-radius:8px;font-size:13px;opacity:0;transition:.2s;pointer-events:none;z-index:9999;}
 #toast.show{opacity:0.95}
 


### PR DESCRIPTION
## Summary
- replace the fixed grid step select with a numeric field and helpful presets so designers can enter custom sizes
- restyle the grid controls to accommodate the new input and unit label
- overhaul grid management logic to support arbitrary step values, persist them in saves, and commit changes to history

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd434972688333bad8362697f1bd8b