### PR TITLE
feat: add snapping candidates and stabilize measurements

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,22 @@
 "use strict";
 (() => {
     // --- CONSTANTS & STATE ---
+    const CONST = {
+        GRID: 0.1,                 // базовый шаг сетки в метрах
+        SNAP_EPS_PX: 8,            // радиус привязки в экранных пикселях
+        WALL: { THICK_DEFAULT: 0.2 },
+        OPENING: { EDGE_MIN: 0.2 },
+        NORMS: {
+            PASSAGE_GUEST_MIN: 1.0,
+            PASSAGE_STAFF_MIN: 0.9,
+            TURN_RADIUS_MIN: 1.5,
+        },
+        COST: {
+            FLOOR_PER_M2: 40,
+            BASEBOARD_PER_M: 5,
+            OPENING_UNIT: 50,
+        },
+    };
     const LOCAL_STORAGE_KEY = 'layout-v10-pro'; // Incremented version to avoid loading old potentially corrupt data
     const dom = {
         svg: document.getElementById('svg'),
@@ -41,6 +57,7 @@
         toolDoor: document.getElementById('tool-door'),
         toolWindow: document.getElementById('tool-window'),
         toolMeasure: document.getElementById('tool-measure'),
+        snapMarkers: document.getElementById('snap-markers'),
         wallPreview: document.getElementById('wall-preview'),
         toggleSidebar: document.getElementById('toggle-sidebar'),
         toggleProperties: document.getElementById('toggle-properties'),
@@ -69,8 +86,9 @@
         selectedComponent: null,
         objectCounter: 0,
         isShiftHeld: false,
-        gridSize: 50,
         pixelsPerMeter: 50,
+        gridStepMeters: CONST.GRID,
+        gridSize: 50 * CONST.GRID,
         history: { stack: [], idx: -1, lock: false },
         activeTool: 'pointer',
         currentWallPoints: [],
@@ -85,12 +103,13 @@
         panStart: null,
         panViewBox: null,
         isSpaceDown: false,
+        isAltDown: false,
         // Хранилище для наложений анализа (для будущих расширений)
         analysisOverlays: [],
         // Нормативы. Все значения в метрах.
-        normativeCorridorGuest: 1.0,
-        normativeCorridorStaff: 1.0,
-        normativeRadius: 3.0,
+        normativeCorridorGuest: CONST.NORMS.PASSAGE_GUEST_MIN,
+        normativeCorridorStaff: CONST.NORMS.PASSAGE_STAFF_MIN,
+        normativeRadius: CONST.NORMS.TURN_RADIUS_MIN,
         // Хранилище результатов последнего анализа (для экспорта CSV)
         lastAnalysis: null,
         // Хранилище выбранного узла стены для редактирования
@@ -116,6 +135,8 @@
         economy: { finish: 35, perimeter: 8, engineering: 20 },
         premium: { finish: 85, perimeter: 18, engineering: 55 }
     };
+    const GRID_MIN_METERS = 0.05;
+    const GRID_MAX_METERS = 20;
     const utils = {
         showToast(msg, ms = 1500) { dom.toast.textContent = msg; dom.toast.classList.add('show'); clearTimeout(this.showToast.t); this.showToast.t = setTimeout(() => dom.toast.classList.remove('show'), ms); },
         toSVGPoint(x, y) { const p = dom.svg.createSVGPoint(); p.x = x; p.y = y; return p.matrixTransform(dom.svg.getScreenCTM().inverse()); },
@@ -178,6 +199,185 @@
         }
         const factor = 1 / (6 * area);
         return { x: cx * factor, y: cy * factor };
+    }
+
+    const snapState = {
+        markerPool: [],
+    };
+
+    function getSnapRadiusSvg() {
+        const delta = utils.screenDeltaToSVG(CONST.SNAP_EPS_PX, 0);
+        const radius = Math.hypot(delta.dx, delta.dy);
+        return Number.isFinite(radius) && radius > 0 ? radius : CONST.SNAP_EPS_PX;
+    }
+
+    function addSnapCandidate(list, seen, pt) {
+        if (!pt || !Number.isFinite(pt.x) || !Number.isFinite(pt.y)) return;
+        const key = `${Math.round(pt.x * 1000) / 1000}_${Math.round(pt.y * 1000) / 1000}`;
+        if (seen.has(key)) return;
+        seen.add(key);
+        list.push({ x: pt.x, y: pt.y });
+    }
+
+    function segmentIntersection(a1, a2, b1, b2) {
+        const d = (a2.x - a1.x) * (b2.y - b1.y) - (a2.y - a1.y) * (b2.x - b1.x);
+        if (Math.abs(d) < 1e-9) return null;
+        const ua = ((b2.x - b1.x) * (a1.y - b1.y) - (b2.y - b1.y) * (a1.x - b1.x)) / d;
+        const ub = ((a2.x - a1.x) * (a1.y - b1.y) - (a2.y - a1.y) * (a1.x - b1.x)) / d;
+        if (ua < 0 || ua > 1 || ub < 0 || ub > 1) return null;
+        return {
+            x: a1.x + ua * (a2.x - a1.x),
+            y: a1.y + ua * (a2.y - a1.y),
+        };
+    }
+
+    function gatherSnapCandidates(point) {
+        const candidates = [];
+        const seen = new Set();
+        if (!point) return candidates;
+
+        const step = state.gridSize;
+        if (Number.isFinite(step) && step > 0) {
+            const gx = point.x / step;
+            const gy = point.y / step;
+            const ix = Math.floor(gx);
+            const iy = Math.floor(gy);
+            for (let dx = -1; dx <= 1; dx++) {
+                for (let dy = -1; dy <= 1; dy++) {
+                    addSnapCandidate(candidates, seen, {
+                        x: (ix + dx) * step,
+                        y: (iy + dy) * step,
+                    });
+                }
+            }
+        }
+
+        const segments = [];
+        wallStore.forEach(model => {
+            const pts = Array.isArray(model.points) ? model.points : [];
+            pts.forEach(pt => addSnapCandidate(candidates, seen, pt));
+            const { segments: segs } = getWallSegments(model);
+            segs.forEach(seg => {
+                segments.push(seg);
+                addSnapCandidate(candidates, seen, {
+                    x: (seg.a.x + seg.b.x) / 2,
+                    y: (seg.a.y + seg.b.y) / 2,
+                });
+            });
+        });
+
+        if (Array.isArray(state.currentWallPoints)) {
+            state.currentWallPoints.forEach(pt => addSnapCandidate(candidates, seen, pt));
+        }
+
+        for (let i = 0; i < segments.length; i++) {
+            for (let j = i + 1; j < segments.length; j++) {
+                const inter = segmentIntersection(segments[i].a, segments[i].b, segments[j].a, segments[j].b);
+                if (inter) addSnapCandidate(candidates, seen, inter);
+            }
+        }
+
+        if (dom.itemsContainer) {
+            const items = Array.from(dom.itemsContainer.querySelectorAll('.layout-object'));
+            items.forEach(el => {
+                if (el.dataset.visible === 'false' || el.style.display === 'none') return;
+                const model = getModel(el);
+                if (!model) return;
+                const halfW = Math.abs(model.ow || 0) * Math.abs(model.sx || 0) / 2;
+                const halfH = Math.abs(model.oh || 0) * Math.abs(model.sy || 0) / 2;
+                const rad = (model.a || 0) * Math.PI / 180;
+                const cos = Math.cos(rad);
+                const sin = Math.sin(rad);
+                const corners = [
+                    { x: -halfW, y: -halfH },
+                    { x: halfW, y: -halfH },
+                    { x: halfW, y: halfH },
+                    { x: -halfW, y: halfH },
+                ];
+                corners.forEach(c => {
+                    const rx = c.x * cos - c.y * sin + model.x;
+                    const ry = c.x * sin + c.y * cos + model.y;
+                    addSnapCandidate(candidates, seen, { x: rx, y: ry });
+                });
+                addSnapCandidate(candidates, seen, { x: model.x, y: model.y });
+            });
+        }
+
+        return candidates;
+    }
+
+    function setSnapMarkers(points, primaryPoint) {
+        const group = dom.snapMarkers;
+        if (!group) return;
+        const snapRadius = Math.max(2, getSnapRadiusSvg() * 0.45);
+        for (let i = snapState.markerPool.length; i < points.length; i++) {
+            const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+            circle.setAttribute('r', snapRadius);
+            group.appendChild(circle);
+            snapState.markerPool.push(circle);
+        }
+        snapState.markerPool.forEach((marker, idx) => {
+            if (idx < points.length) {
+                const pt = points[idx];
+                marker.setAttribute('display', '');
+                marker.setAttribute('cx', pt.x);
+                marker.setAttribute('cy', pt.y);
+                marker.setAttribute('r', snapRadius);
+                if (primaryPoint && Math.abs(primaryPoint.x - pt.x) < 1e-6 && Math.abs(primaryPoint.y - pt.y) < 1e-6) {
+                    marker.setAttribute('data-primary', 'true');
+                } else {
+                    marker.removeAttribute('data-primary');
+                }
+                marker.removeAttribute('opacity');
+            } else {
+                marker.setAttribute('display', 'none');
+                marker.removeAttribute('data-primary');
+            }
+        });
+    }
+
+    function clearSnapMarkers() {
+        snapState.markerPool.forEach(marker => {
+            marker.setAttribute('display', 'none');
+            marker.removeAttribute('data-primary');
+        });
+    }
+
+    function snapSvgPoint(point, { preview = true, altKey = false } = {}) {
+        if (!point) return { point: point ?? { x: 0, y: 0 }, snapped: false };
+        if (altKey || state.isAltDown) {
+            if (preview) clearSnapMarkers();
+            return { point: { x: point.x, y: point.y }, snapped: false };
+        }
+        const candidates = gatherSnapCandidates(point);
+        const radius = getSnapRadiusSvg();
+        let best = null;
+        const nearby = [];
+        candidates.forEach(pt => {
+            const d = distance(point, pt);
+            if (d <= radius) {
+                nearby.push({ pt, dist: d });
+                if (!best || d < best.dist) best = { pt, dist: d };
+            }
+        });
+        if (preview) {
+            if (nearby.length) {
+                nearby.sort((a, b) => a.dist - b.dist);
+                setSnapMarkers(nearby.map(n => n.pt), best?.pt);
+            } else {
+                clearSnapMarkers();
+            }
+        }
+        if (best) {
+            return { point: { x: best.pt.x, y: best.pt.y }, snapped: true };
+        }
+        return { point: { x: point.x, y: point.y }, snapped: false };
+    }
+
+    function snapValueToGrid(value) {
+        const step = state.gridSize;
+        if (!Number.isFinite(step) || step <= 0) return value;
+        return Math.round(value / step) * step;
     }
 
     // --- WALL TYPE HELPERS & UI ---
@@ -624,12 +824,6 @@
         const index = parseInt(target.dataset.index, 10);
         state.selectedWallHandle = { wall: wallEl, index };
         updateWallHandles(wallEl);
-        if (e.altKey) {
-            if (removeWallVertex(wallEl, index)) {
-                commit('wall_vertex_remove');
-            }
-            return;
-        }
         wallHandleDrag = { wall: wallEl, index };
         window.addEventListener('pointermove', onWallHandlePointerMove);
         window.addEventListener('pointerup', onWallHandlePointerUp, { once: true });
@@ -641,7 +835,7 @@
         const model = getWallModel(wallEl);
         if (!model) return;
         const p = utils.toSVGPoint(e.clientX, e.clientY);
-        const snapped = { x: snap(p.x), y: snap(p.y) };
+        const { point: snapped } = snapSvgPoint(p, { altKey: e.altKey });
         model.points[wallHandleDrag.index] = snapped;
         updateWallElementGeometry(wallEl);
     }
@@ -651,6 +845,7 @@
         updateWallElementGeometry(wallHandleDrag.wall);
         commit('wall_vertex_move');
         wallHandleDrag = null;
+        clearSnapMarkers();
     }
 
     function onWallHandleDoubleClick(e) {
@@ -673,11 +868,12 @@
         if (!model) return;
         const index = parseInt(target.dataset.index, 10);
         const p = utils.toSVGPoint(e.clientX, e.clientY);
-        const snapped = { x: snap(p.x), y: snap(p.y) };
+        const { point: snapped } = snapSvgPoint(p, { altKey: e.altKey });
         insertWallVertex(wallEl, index, snapped);
         state.selectedWallHandle = { wall: wallEl, index };
         updateWallHandles(wallEl);
         commit('wall_vertex_add');
+        clearSnapMarkers();
     }
 
     function makeWallInteractive(wallEl) {
@@ -690,7 +886,7 @@
                 const model = getWallModel(wallEl);
                 if (!model) return;
                 const p = utils.toSVGPoint(e.clientX, e.clientY);
-                const snapped = { x: snap(p.x), y: snap(p.y) };
+                const { point: snapped } = snapSvgPoint(p, { altKey: e.altKey });
                 // Найдём ближайший сегмент для вставки
                 const pts = model.points;
                 const count = pts.length;
@@ -711,6 +907,7 @@
                 state.selectedWallHandle = { wall: wallEl, index: bestIdx };
                 updateWallHandles(wallEl);
                 commit('wall_vertex_add');
+                clearSnapMarkers();
             });
         }
         updateWallHandles(wallEl);
@@ -736,6 +933,7 @@
         dom.previewsContainer.innerHTML = '';
         state.pendingComponentPlacement = null;
         hideWallLengthPreview();
+        clearSnapMarkers();
         // Покидая режим измерения — сохраняем линии, но убираем предпросмотр
         if (state.activeTool !== 'measure') {
             resetMeasurementPreview();
@@ -763,6 +961,7 @@
         state.currentWallPoints = [];
         dom.wallPreview.setAttribute('points', '');
         hideWallLengthPreview();
+        clearSnapMarkers();
     }
     function placeWallComponent(type, placement) {
         const wallEl = ensureWallElement(placement?.wallEl || (state.pendingComponentPlacement?.wallEl));
@@ -802,19 +1001,108 @@
     }
     
     // --- GRID & GUIDES ---
-    function snap(v) { return Math.round(v / state.gridSize) * state.gridSize; }
-    function snapSelectedToGrid(el, sizeToo = false) { const m = getModel(el); m.x = snap(m.x); m.y = snap(m.y); if (sizeToo) { m.sx = Math.max(0.1, (snap(m.ow * m.sx)) / m.ow); m.sy = Math.max(0.1, (snap(m.oh * m.sy)) / m.oh); } setModel(el, m); }
-    function updateGridSize() {
-        state.gridSize = +dom.gridSelect.value;
-        const w = String(state.gridSize);
+    function snapSelectedToGrid(el, sizeToo = false) {
+        const m = getModel(el);
+        const { point } = snapSvgPoint({ x: m.x, y: m.y }, { preview: false });
+        m.x = point.x;
+        m.y = point.y;
+        if (sizeToo) {
+            const snappedW = snapValueToGrid(m.ow * m.sx);
+            const snappedH = snapValueToGrid(m.oh * m.sy);
+            if (Number.isFinite(snappedW) && m.ow) {
+                m.sx = Math.max(0.1, snappedW / m.ow);
+            }
+            if (Number.isFinite(snappedH) && m.oh) {
+                m.sy = Math.max(0.1, snappedH / m.oh);
+            }
+        }
+        setModel(el, m);
+    }
+    function formatGridMeters(value) { return (Math.round(value * 1000) / 1000).toString(); }
+    function applyGridPatternSize(sizePx) {
+        if (!Number.isFinite(sizePx) || sizePx <= 0) return;
+        const normalized = Math.round(sizePx * 1000) / 1000;
+        state.gridSize = normalized;
+        if (!dom.gridPattern) return;
+        const w = normalized.toString();
         dom.gridPattern.setAttribute('width', w);
         dom.gridPattern.setAttribute('height', w);
         const path = dom.gridPattern.querySelector('path');
         path?.setAttribute('d', `M ${w} 0 L 0 0 0 ${w}`);
-        const selectedOption = dom.gridSelect.options[dom.gridSelect.selectedIndex];
-        const metersPerCell = parseFloat(selectedOption?.dataset?.meters || selectedOption?.textContent) || 1;
-        state.pixelsPerMeter = metersPerCell ? state.gridSize / metersPerCell : state.gridSize;
-        utils.showToast(`Сетка ${selectedOption?.text || ''}`);
+    }
+    function updateGridSize({ silent = false, deferInvalid = false } = {}) {
+        if (!dom.gridSelect) return;
+
+        let pxPerMeter = state.pixelsPerMeter;
+        if (!Number.isFinite(pxPerMeter) || pxPerMeter <= 0) {
+            pxPerMeter = 50;
+            state.pixelsPerMeter = pxPerMeter;
+        }
+
+        let fallbackMeters = state.gridStepMeters;
+        if (!Number.isFinite(fallbackMeters) || fallbackMeters <= 0) {
+            const derived = pxPerMeter ? state.gridSize / pxPerMeter : 0;
+            fallbackMeters = Number.isFinite(derived) && derived > 0 ? derived : CONST.GRID;
+        }
+        fallbackMeters = Math.round(fallbackMeters * 1000) / 1000;
+
+        const rawValue = (dom.gridSelect.value ?? '').trim();
+        let commitMeters = null;
+        let effectiveMeters = null;
+        let inputValueAfter = null;
+
+        if (!rawValue) {
+            if (deferInvalid) return;
+            commitMeters = fallbackMeters;
+            effectiveMeters = fallbackMeters;
+            inputValueAfter = fallbackMeters;
+        } else if (deferInvalid && /[.,]$/.test(rawValue)) {
+            return;
+        } else {
+            const normalizedValue = rawValue.replace(/,/g, '.');
+            const rawMeters = parseFloat(normalizedValue);
+            if (!Number.isFinite(rawMeters) || rawMeters <= 0) {
+                if (deferInvalid) return;
+                commitMeters = fallbackMeters;
+                effectiveMeters = fallbackMeters;
+                inputValueAfter = fallbackMeters;
+            } else {
+                const processedMeters = deferInvalid ? rawMeters : utils.clamp(rawMeters, GRID_MIN_METERS, GRID_MAX_METERS);
+                const roundedMeters = Math.round(processedMeters * 1000) / 1000;
+                effectiveMeters = deferInvalid ? processedMeters : roundedMeters;
+                if (!deferInvalid) {
+                    commitMeters = roundedMeters;
+                    inputValueAfter = roundedMeters;
+                }
+            }
+        }
+
+        if (!Number.isFinite(effectiveMeters) || effectiveMeters <= 0) {
+            return;
+        }
+
+        if (!deferInvalid && inputValueAfter != null) {
+            dom.gridSelect.value = formatGridMeters(inputValueAfter);
+        }
+
+        applyGridPatternSize(effectiveMeters * pxPerMeter);
+        state.pixelsPerMeter = pxPerMeter;
+
+        let changed = false;
+        if (commitMeters != null) {
+            const prevMeters = Number.isFinite(state.gridStepMeters) && state.gridStepMeters > 0 ? state.gridStepMeters : fallbackMeters;
+            changed = Math.abs(prevMeters - commitMeters) > 1e-6;
+            state.gridStepMeters = commitMeters;
+        }
+
+        if (!silent && !deferInvalid) {
+            const messageMeters = state.gridStepMeters;
+            const formatted = messageMeters.toLocaleString('ru-RU', {
+                maximumFractionDigits: messageMeters < 1 ? 2 : 1
+            });
+            utils.showToast(`Сетка ${formatted} м`);
+            if (changed) commit('grid_step');
+        }
     }
     function drawGuideLine(x1, y1, x2, y2, id) { let l = document.getElementById(id); if (!l) { l = document.createElementNS('http://www.w3.org/2000/svg', 'line'); l.id = id; l.setAttribute('stroke', '#8ecae6'); l.setAttribute('stroke-dasharray', '4 4'); l.setAttribute('vector-effect', 'non-scaling-stroke'); dom.svg.insertBefore(l, dom.itemsContainer); } l.setAttribute('x1', x1); l.setAttribute('y1', y1); l.setAttribute('x2', x2); l.setAttribute('y2', y2); }
     function hideGuide(id) { document.getElementById(id)?.remove(); }
@@ -865,50 +1153,129 @@
     }
 
     // --- MEASUREMENT TOOL ---
+    const measurementRenderState = {
+        staticGroup: null,
+        previewGroup: null,
+        previewLine: null,
+        previewText: null,
+        entries: new Map(),
+    };
+
     function resetMeasurementPreview() {
         state.measurePoints = [];
         renderMeasurementOverlay();
+        clearSnapMarkers();
     }
-    function renderMeasurementOverlay(preview) {
+    function ensureMeasurementGroups() {
         const layer = dom.measurementLayer;
+        if (!layer) return null;
+        if (!measurementRenderState.staticGroup || measurementRenderState.staticGroup.parentNode !== layer) {
+            measurementRenderState.staticGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+            measurementRenderState.staticGroup.dataset.role = 'measurement-static';
+            layer.appendChild(measurementRenderState.staticGroup);
+        }
+        if (!measurementRenderState.previewGroup || measurementRenderState.previewGroup.parentNode !== layer) {
+            measurementRenderState.previewGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+            measurementRenderState.previewGroup.dataset.role = 'measurement-preview';
+            layer.appendChild(measurementRenderState.previewGroup);
+            measurementRenderState.previewLine = null;
+            measurementRenderState.previewText = null;
+        }
+        if (!measurementRenderState.previewLine) {
+            measurementRenderState.previewLine = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+            measurementRenderState.previewLine.setAttribute('stroke-dasharray', '6 4');
+            measurementRenderState.previewLine.setAttribute('opacity', '0');
+            measurementRenderState.previewLine.setAttribute('marker-start', 'url(#dim-arrow)');
+            measurementRenderState.previewLine.setAttribute('marker-end', 'url(#dim-arrow)');
+            measurementRenderState.previewGroup.appendChild(measurementRenderState.previewLine);
+        }
+        if (!measurementRenderState.previewText) {
+            measurementRenderState.previewText = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+            measurementRenderState.previewText.setAttribute('opacity', '0');
+            measurementRenderState.previewText.setAttribute('paint-order', 'stroke');
+            measurementRenderState.previewText.setAttribute('stroke', 'white');
+            measurementRenderState.previewText.setAttribute('stroke-width', '0.5');
+            measurementRenderState.previewText.setAttribute('font-size', '14');
+            measurementRenderState.previewText.setAttribute('font-weight', 'bold');
+            measurementRenderState.previewGroup.appendChild(measurementRenderState.previewText);
+        }
+        return layer;
+    }
+
+    function updateMeasurementGraphics(line, text, measurement, pixelsPerMeter, isPreview = false) {
+        const p0 = measurement.p0;
+        const p1 = measurement.p1;
+        line.setAttribute('x1', p0.x);
+        line.setAttribute('y1', p0.y);
+        line.setAttribute('x2', p1.x);
+        line.setAttribute('y2', p1.y);
+        if (isPreview) {
+            line.setAttribute('stroke-dasharray', '6 4');
+            line.setAttribute('opacity', '0.7');
+        } else {
+            line.removeAttribute('stroke-dasharray');
+            line.setAttribute('opacity', '1');
+        }
+        const dist = distance(p0, p1);
+        const meters = measurement.meters ?? (dist / pixelsPerMeter);
+        const angleDeg = Math.round((measurement.angle ?? ((Math.atan2(p1.y - p0.y, p1.x - p0.x) * 180 / Math.PI) + 360)) % 360);
+        const midx = (p0.x + p1.x) / 2;
+        const midy = (p0.y + p1.y) / 2;
+        text.setAttribute('x', midx + 4);
+        text.setAttribute('y', midy - 4);
+        text.textContent = `${meters.toFixed(2)} м • ${angleDeg}°`;
+        if (isPreview) {
+            text.setAttribute('opacity', '0.6');
+        } else {
+            text.removeAttribute('opacity');
+        }
+    }
+
+    function renderMeasurementOverlay(preview) {
+        const layer = ensureMeasurementGroups();
         if (!layer) return;
-        layer.innerHTML = '';
         const pixelsPerMeter = state.pixelsPerMeter || state.gridSize || 1;
-        const draw = (measurement, isPreview = false) => {
-            if (!measurement) return;
-            const p0 = measurement.p0;
-            const p1 = measurement.p1;
-            const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
-            line.setAttribute('x1', p0.x);
-            line.setAttribute('y1', p0.y);
-            line.setAttribute('x2', p1.x);
-            line.setAttribute('y2', p1.y);
-            line.setAttribute('stroke', getComputedStyle(document.documentElement).getPropertyValue('--accent') || '#0d6efd');
-            line.setAttribute('stroke-width', 3);
-            line.setAttribute('marker-start', 'url(#dim-arrow)');
-            line.setAttribute('marker-end', 'url(#dim-arrow)');
-            if (isPreview) line.setAttribute('stroke-dasharray', '6 4');
-            layer.appendChild(line);
-            const dist = distance(p0, p1);
-            const meters = (measurement.meters ?? (dist / pixelsPerMeter)).toFixed(2);
-            const angleDeg = Math.round((measurement.angle ?? ((Math.atan2(p1.y - p0.y, p1.x - p0.x) * 180 / Math.PI) + 360)) % 360);
-            const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
-            const midx = (p0.x + p1.x) / 2;
-            const midy = (p0.y + p1.y) / 2;
-            text.setAttribute('x', midx + 4);
-            text.setAttribute('y', midy - 4);
-            text.setAttribute('fill', getComputedStyle(document.documentElement).getPropertyValue('--accent') || '#0d6efd');
-            text.setAttribute('font-size', '14');
-            text.setAttribute('font-weight', 'bold');
-            text.setAttribute('stroke', 'white');
-            text.setAttribute('stroke-width', '0.5');
-            text.setAttribute('paint-order', 'stroke');
-            text.textContent = `${meters} м • ${angleDeg}°`;
-            if (isPreview) text.setAttribute('opacity', '0.6');
-            layer.appendChild(text);
-        };
-        state.measurements.forEach(m => draw(m, false));
-        if (preview) draw(preview, true);
+        const active = new Set();
+
+        state.measurements.forEach(measurement => {
+            let entry = measurementRenderState.entries.get(measurement.id);
+            if (!entry) {
+                const group = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+                const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+                line.setAttribute('marker-start', 'url(#dim-arrow)');
+                line.setAttribute('marker-end', 'url(#dim-arrow)');
+                const text = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+                text.setAttribute('paint-order', 'stroke');
+                text.setAttribute('stroke', 'white');
+                text.setAttribute('stroke-width', '0.5');
+                text.setAttribute('font-size', '14');
+                text.setAttribute('font-weight', 'bold');
+                group.appendChild(line);
+                group.appendChild(text);
+                measurementRenderState.staticGroup.appendChild(group);
+                entry = { group, line, text };
+                measurementRenderState.entries.set(measurement.id, entry);
+            }
+            updateMeasurementGraphics(entry.line, entry.text, measurement, pixelsPerMeter, false);
+            active.add(measurement.id);
+        });
+
+        Array.from(measurementRenderState.entries.keys()).forEach(id => {
+            if (!active.has(id)) {
+                const entry = measurementRenderState.entries.get(id);
+                entry?.group.remove();
+                measurementRenderState.entries.delete(id);
+            }
+        });
+
+        if (preview && preview.p0 && preview.p1) {
+            updateMeasurementGraphics(measurementRenderState.previewLine, measurementRenderState.previewText, preview, pixelsPerMeter, true);
+            measurementRenderState.previewLine.setAttribute('display', '');
+            measurementRenderState.previewText.setAttribute('display', '');
+        } else {
+            if (measurementRenderState.previewLine) measurementRenderState.previewLine.setAttribute('display', 'none');
+            if (measurementRenderState.previewText) measurementRenderState.previewText.setAttribute('display', 'none');
+        }
     }
     function addMeasurement(p0, p1) {
         const pixels = distance(p0, p1);
@@ -927,6 +1294,7 @@
         state.measurements.push(measurement);
         renderMeasurementOverlay();
         renderMeasurementTable();
+        clearSnapMarkers();
         commit('measure_add');
     }
     function removeMeasurement(id) {
@@ -935,6 +1303,7 @@
             state.measurements.splice(idx, 1);
             renderMeasurementOverlay();
             renderMeasurementTable();
+            clearSnapMarkers();
             commit('measure_remove');
         }
     }
@@ -955,6 +1324,7 @@
         state.measureCounter = 0;
         renderMeasurementTable();
         renderMeasurementOverlay();
+        clearSnapMarkers();
         commit('measure_clear');
     }
 
@@ -1407,6 +1777,10 @@
                 offset: comp.offset || 0
             })),
             wallDefaults: { type: state.defaultWallType },
+            grid: {
+                stepMeters: Number.isFinite(state.gridStepMeters) && state.gridStepMeters > 0 ? state.gridStepMeters : 1,
+                pixelsPerMeter: Number.isFinite(state.pixelsPerMeter) && state.pixelsPerMeter > 0 ? state.pixelsPerMeter : 50
+            },
             measurements: state.measurements.map(m => ({ ...m })),
             normatives: {
                 corridorGuest: state.normativeCorridorGuest,
@@ -1439,6 +1813,28 @@
         componentIdMap.clear();
         state.componentCounter = 0;
         state.pendingComponentPlacement = null;
+
+        const savedGrid = data?.grid;
+        if (savedGrid) {
+            const pxPerMeter = parseFloat(savedGrid.pixelsPerMeter);
+            if (Number.isFinite(pxPerMeter) && pxPerMeter > 0) {
+                state.pixelsPerMeter = pxPerMeter;
+            }
+            const stepMeters = parseFloat(savedGrid.stepMeters ?? savedGrid.step ?? savedGrid.meters);
+            if (Number.isFinite(stepMeters) && stepMeters > 0) {
+                state.gridStepMeters = Math.round(stepMeters * 1000) / 1000;
+            }
+        }
+        if (!Number.isFinite(state.pixelsPerMeter) || state.pixelsPerMeter <= 0) {
+            state.pixelsPerMeter = 50;
+        }
+        if (!Number.isFinite(state.gridStepMeters) || state.gridStepMeters <= 0) {
+            state.gridStepMeters = CONST.GRID;
+        }
+        if (dom.gridSelect) {
+            dom.gridSelect.value = formatGridMeters(state.gridStepMeters);
+            updateGridSize({ silent: true });
+        }
 
         state.defaultWallType = ensureWallType(data?.wallDefaults?.type || state.defaultWallType);
         highlightWallType(state.defaultWallType);
@@ -1597,6 +1993,11 @@
     // --- EVENT HANDLERS ---
     function onLayersClick(e) { const li = e.target.closest('li'); if (!li) return; const id = li.dataset.id; const el = dom.itemsContainer.querySelector(`[data-id="${id}"]`); if (!el) return; const model = getModel(el); if (e.target.classList.contains('layer-vis')) { model.visible = !model.visible; el.style.display = model.visible ? '' : 'none'; setModel(el, model); commit('visibility'); } else if (e.target.classList.contains('layer-lock')) { model.locked = !model.locked; setModel(el, model); commit('lock'); } else { if (model.locked) { utils.showToast('Объект заблокирован'); return; } selectObject(el); } }
     function handleKeyDown(e) {
+        if (e.key === 'Alt') {
+            state.isAltDown = true;
+            clearSnapMarkers();
+        }
+
         // не реагировать на ввод в полях
         if (e.target.matches('input,select')) return;
 
@@ -1755,6 +2156,10 @@
         if (e.key === 'Shift') state.isShiftHeld = false;
         // отпускание пробела отключает панорамирование
         if (e.code === 'Space') state.isSpaceDown = false;
+        if (e.key === 'Alt') {
+            state.isAltDown = false;
+            clearSnapMarkers();
+        }
         if (state.selectedObject && ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
             snapSelectedToGrid(state.selectedObject);
             commit('nudge');
@@ -1772,6 +2177,7 @@
 
             // Панорамирование средней кнопкой или пробелом
             if ((e.button === 1 || state.isSpaceDown) && state.activeTool === 'pointer') {
+                clearSnapMarkers();
                 startPan(e);
                 return;
             }
@@ -1779,12 +2185,13 @@
             // Измерительный инструмент
             if (state.activeTool === 'measure') {
                 const p = utils.toSVGPoint(e.clientX, e.clientY);
+                const { point: snapped } = snapSvgPoint(p, { altKey: e.altKey });
                 if (state.measurePoints.length === 0) {
-                    state.measurePoints.push({ x: p.x, y: p.y });
+                    state.measurePoints.push(snapped);
                     renderMeasurementOverlay();
                 } else if (state.measurePoints.length === 1) {
                     const start = state.measurePoints[0];
-                    addMeasurement(start, { x: p.x, y: p.y });
+                    addMeasurement(start, snapped);
                     state.measurePoints = [];
                 }
                 return;
@@ -1793,7 +2200,7 @@
             // Рисование стены
             if (state.activeTool === 'wall') {
                 const p = utils.toSVGPoint(e.clientX, e.clientY);
-                const snappedP = { x: snap(p.x), y: snap(p.y) };
+                const { point: snappedP } = snapSvgPoint(p, { altKey: e.altKey });
                 state.currentWallPoints.push(snappedP);
                 const pointsAttr = state.currentWallPoints.map(pt => `${pt.x},${pt.y}`).join(' ');
                 dom.wallPreview.setAttribute('points', pointsAttr);
@@ -1814,6 +2221,7 @@
                     const interactive = e.target.closest('.layout-object, .wall-component, .wall');
                     if (!interactive) {
                         e.preventDefault();
+                        clearSnapMarkers();
                         startPan(e);
                         return;
                     }
@@ -1834,7 +2242,7 @@
             // Обновление превью стены и длины сегмента
             if (tool === 'wall') {
                 if (state.currentWallPoints.length > 0) {
-                    const snappedP = { x: snap(p.x), y: snap(p.y) };
+                    const { point: snappedP } = snapSvgPoint(p, { altKey: e.altKey });
                     const pointsAttr = [...state.currentWallPoints, snappedP].map(pt => `${pt.x},${pt.y}`).join(' ');
                     dom.wallPreview.setAttribute('points', pointsAttr);
                     const lastPoint = state.currentWallPoints[state.currentWallPoints.length - 1];
@@ -1864,18 +2272,23 @@
             else if (tool === 'measure' && state.measurePoints.length === 1) {
                 hideWallLengthPreview();
                 const p0 = state.measurePoints[0];
+                const { point: snappedP } = snapSvgPoint(p, { altKey: e.altKey });
                 const preview = {
                     p0,
-                    p1: { x: p.x, y: p.y },
-                    meters: distance(p0, p) / (state.pixelsPerMeter || state.gridSize || 1),
-                    angle: (Math.atan2(p.y - p0.y, p.x - p0.x) * 180 / Math.PI + 360) % 360
+                    p1: snappedP,
+                    meters: distance(p0, snappedP) / (state.pixelsPerMeter || state.gridSize || 1),
+                    angle: (Math.atan2(snappedP.y - p0.y, snappedP.x - p0.x) * 180 / Math.PI + 360) % 360
                 };
                 renderMeasurementOverlay(preview);
             } else {
                 hideWallLengthPreview();
+                clearSnapMarkers();
             }
         }));
-        dom.svg.addEventListener('mouseleave', hideWallLengthPreview);
+        dom.svg.addEventListener('mouseleave', () => {
+            hideWallLengthPreview();
+            clearSnapMarkers();
+        });
         // Контекстное меню открывается только в режиме указателя. По ПКМ выбираем объект и отображаем меню.
         dom.svg.addEventListener('contextmenu', e => {
             e.preventDefault();
@@ -1916,6 +2329,13 @@
         rateInputs.forEach(input => input?.addEventListener('change', () => { updateRatesFromInputs(); analysisLayout({ silent: true }); }));
         window.addEventListener('keydown', handleKeyDown);
         window.addEventListener('keyup', handleKeyUp);
+        window.addEventListener('blur', () => {
+            state.isSpaceDown = false;
+            state.isShiftHeld = false;
+            state.isAltDown = false;
+            clearSnapMarkers();
+            endPan();
+        });
         dom.toggleSidebar?.addEventListener('click', () => dom.sidebar.classList.toggle('visible'));
         dom.toggleProperties?.addEventListener('click', () => dom.properties.classList.toggle('visible'));
         dom.main.addEventListener('click', e => { if (window.innerWidth <= 1024 && !e.target.closest('.ui-bar')) { dom.sidebar.classList.remove('visible'); dom.properties.classList.remove('visible'); }});
@@ -1925,7 +2345,10 @@
             if (button) button.addEventListener('click', () => toggleTool(tool));
         });
 
-        dom.gridSelect.addEventListener('change', updateGridSize);
+        if (dom.gridSelect) {
+            dom.gridSelect.addEventListener('input', () => updateGridSize({ silent: true, deferInvalid: true }));
+            dom.gridSelect.addEventListener('change', () => updateGridSize());
+        }
         dom.btnExport.addEventListener('click', () => { const a = document.createElement('a'); a.href = URL.createObjectURL(new Blob([JSON.stringify(snapshot(), null, 2)], { type: 'application/json' })); a.download = 'layout.json'; a.click(); URL.revokeObjectURL(a.href); });
         dom.btnImport.addEventListener('click', () => dom.fileImport.click());
         dom.fileImport.addEventListener('change', e => { const f = e.target.files?.[0]; if (!f) return; const r = new FileReader(); r.onload = () => { try { const data = JSON.parse(r.result); restore(data); commit('import'); utils.showToast('План импортирован'); } catch (err) { utils.showToast('Ошибка импорта'); } }; r.readAsText(f); });
@@ -2002,7 +2425,7 @@
 
         // Final setup
         toggleTool('pointer');
-        updateGridSize();
+        updateGridSize({ silent: true });
         renderMeasurementOverlay();
         renderMeasurementTable();
         syncNormativeControls();

--- a/index.html
+++ b/index.html
@@ -58,12 +58,20 @@
                 </div>
                 
                 <div id="grid-controls-bar" class="ui-bar">
-                    <label>Сетка:
-                        <select id="gridStep">
-                            <option value="25" data-meters="0.5">0.5 м</option>
-                            <option value="50" data-meters="1" selected>1 м</option>
-                            <option value="100" data-meters="2">2 м</option>
-                        </select>
+                    <label class="grid-step-control">Сетка:
+                        <input id="gridStep" type="number" value="0.1" min="0.05" step="0.05" list="gridStepPresets" inputmode="decimal" aria-label="Шаг сетки, метры">
+                        <datalist id="gridStepPresets">
+                            <option value="0.1" label="0.1 м"></option>
+                            <option value="0.25" label="0.25 м"></option>
+                            <option value="0.5" label="0.5 м"></option>
+                            <option value="0.75" label="0.75 м"></option>
+                            <option value="1" label="1 м"></option>
+                            <option value="1.5" label="1.5 м"></option>
+                            <option value="2" label="2 м"></option>
+                            <option value="3" label="3 м"></option>
+                            <option value="5" label="5 м"></option>
+                        </datalist>
+                        <span class="grid-step-unit">м</span>
                     </label>
                     <label><input type="checkbox" id="snapGuides" checked> Направляющие</label>
                 </div>
@@ -179,6 +187,7 @@
                         <polyline id="wall-preview" fill="none" stroke="var(--accent)" stroke-width="5" stroke-dasharray="10 5" pointer-events="none" />
                         <g id="previews"></g>
                         <text id="wall-length-label" class="wall-length-label" text-anchor="middle" dominant-baseline="middle" visibility="hidden">0.00 м</text>
+                        <g id="snap-markers" pointer-events="none"></g>
                     </g>
                     <!-- Слой для отображения результатов анализа (помещения, зоны, коллизии) -->
                     <g id="analysis-layer" pointer-events="none"></g>

--- a/style.css
+++ b/style.css
@@ -108,6 +108,21 @@ svg.tool-active { cursor: crosshair; }
   pointer-events: none;
 }
 
+#snap-markers {
+  pointer-events: none;
+}
+
+#snap-markers circle {
+  fill: var(--accent);
+  opacity: 0.25;
+  stroke: none;
+  vector-effect: non-scaling-stroke;
+}
+
+#snap-markers circle[data-primary="true"] {
+  opacity: 0.45;
+}
+
 /* --- Collision highlighting (для анализа коллизий) --- */
 .layout-object.collision .shape {
   stroke: var(--danger) !important;
@@ -197,8 +212,13 @@ svg.tool-active { cursor: crosshair; }
   background:#f6f7f8;
 }
 #grid-controls-bar{right:12px;top:12px;}
-#grid-controls-bar select{border:1px solid var(--border);background:#fff;border-radius:10px;padding:6px 10px;cursor:pointer}
 #grid-controls-bar label{display:flex;gap:6px;align-items:center}
+#grid-controls-bar .grid-step-control{gap:8px;white-space:nowrap}
+#grid-controls-bar input[type="number"]{border:1px solid var(--border);background:#fff;border-radius:10px;padding:6px 10px;width:88px;font-size:14px;line-height:1.3;}
+#grid-controls-bar input[type="number"]::-webkit-outer-spin-button,
+#grid-controls-bar input[type="number"]::-webkit-inner-spin-button{margin:0}
+#grid-controls-bar input[type="number"]{-moz-appearance:textfield}
+#grid-controls-bar .grid-step-unit{font-size:12px;color:var(--muted);}
 #toast{position:absolute;left:50%;top:20px;transform:translateX(-50%);background:#212529;color:#fff;padding:10px 16px;border-radius:8px;font-size:13px;opacity:0;transition:.2s;pointer-events:none;z-index:9999;}
 #toast.show{opacity:0.95}
 


### PR DESCRIPTION
## Summary
- introduce scene constants and a new snapping system that gathers grid, wall, and furniture candidates with optional Alt override and marker feedback
- apply snapping across wall editing, drawing, and measurement tools while exposing soft markers in the preview layer
- reuse measurement overlay elements for previews to eliminate flicker and adjust the UI for the new default grid step and snap markers

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd434972688333bad8362697f1bd8b