### PR TITLE
Render adaptive grid that follows zoom

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,6 +30,8 @@
         toast: document.getElementById('toast'),
         ctx: document.getElementById('ctx'),
         gridPattern: document.getElementById('grid'),
+        gridRect: document.getElementById('grid-surface'),
+        gridLinesGroup: document.getElementById('grid-lines'),
         layersPanel: document.getElementById('layers-panel'),
         layersList: document.getElementById('layers-list'),
         main: document.getElementById('main'),
@@ -203,6 +205,12 @@
 
     const snapState = {
         markerPool: [],
+    };
+
+    const gridRenderState = {
+        majorStride: 5,
+        minorPath: null,
+        majorPath: null,
     };
 
     function getSnapRadiusSvg() {
@@ -1019,6 +1027,121 @@
         setModel(el, m);
     }
     function formatGridMeters(value) { return (Math.round(value * 1000) / 1000).toString(); }
+    function ensureGridRect() {
+        if (dom.gridRect && dom.gridRect.ownerSVGElement) {
+            return dom.gridRect;
+        }
+        const rect = document.getElementById('grid-surface');
+        dom.gridRect = rect;
+        return rect;
+    }
+    function ensureGridLines() {
+        if (!dom.gridLinesGroup || !dom.gridLinesGroup.ownerSVGElement) {
+            const layer = document.getElementById('grid-layer');
+            if (!layer) return null;
+            const group = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+            group.id = 'grid-lines';
+            group.setAttribute('pointer-events', 'none');
+            layer.appendChild(group);
+            dom.gridLinesGroup = group;
+            gridRenderState.minorPath = null;
+            gridRenderState.majorPath = null;
+        }
+        const group = dom.gridLinesGroup;
+        if (!gridRenderState.minorPath || gridRenderState.minorPath.parentNode !== group) {
+            const minor = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            minor.dataset.role = 'grid-minor';
+            minor.setAttribute('fill', 'none');
+            minor.setAttribute('stroke', '#e7ebf2');
+            minor.setAttribute('stroke-width', '0.6');
+            minor.setAttribute('vector-effect', 'non-scaling-stroke');
+            minor.setAttribute('shape-rendering', 'crispEdges');
+            group.appendChild(minor);
+            gridRenderState.minorPath = minor;
+        }
+        if (!gridRenderState.majorPath || gridRenderState.majorPath.parentNode !== group) {
+            const major = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+            major.dataset.role = 'grid-major';
+            major.setAttribute('fill', 'none');
+            major.setAttribute('stroke', '#c7d0dd');
+            major.setAttribute('stroke-width', '1.1');
+            major.setAttribute('vector-effect', 'non-scaling-stroke');
+            major.setAttribute('shape-rendering', 'crispEdges');
+            group.appendChild(major);
+            gridRenderState.majorPath = major;
+        }
+        return group;
+    }
+    function roundTo(value, digits = 3) {
+        const factor = 10 ** digits;
+        return Math.round(value * factor) / factor;
+    }
+    function renderGridLines() {
+        const view = state.viewBox;
+        const step = state.gridSize;
+        if (!view || !Number.isFinite(step) || step <= 0) return;
+        const group = ensureGridLines();
+        if (!group || !gridRenderState.minorPath || !gridRenderState.majorPath) return;
+
+        const margin = Math.max(step * 4, Math.min(view.width, view.height) * 0.25);
+        const startCol = Math.floor((view.x - margin) / step);
+        const endCol = Math.ceil((view.x + view.width + margin) / step);
+        const startRow = Math.floor((view.y - margin) / step);
+        const endRow = Math.ceil((view.y + view.height + margin) / step);
+
+        const x0 = roundTo(view.x - margin, 3);
+        const x1 = roundTo(view.x + view.width + margin, 3);
+        const y0 = roundTo(view.y - margin, 3);
+        const y1 = roundTo(view.y + view.height + margin, 3);
+
+        let minorSegments = '';
+        let majorSegments = '';
+        const stride = Math.max(1, Math.round(gridRenderState.majorStride));
+
+        for (let col = startCol; col <= endCol; col++) {
+            const x = roundTo(col * step, 3);
+            const isMajor = ((col % stride) + stride) % stride === 0;
+            const segment = `M ${x} ${y0} V ${y1}`;
+            if (isMajor) {
+                majorSegments += segment;
+            } else {
+                minorSegments += segment;
+            }
+        }
+        for (let row = startRow; row <= endRow; row++) {
+            const y = roundTo(row * step, 3);
+            const isMajor = ((row % stride) + stride) % stride === 0;
+            const segment = `M ${x0} ${y} H ${x1}`;
+            if (isMajor) {
+                majorSegments += segment;
+            } else {
+                minorSegments += segment;
+            }
+        }
+
+        gridRenderState.minorPath.setAttribute('d', minorSegments || 'M 0 0');
+        gridRenderState.majorPath.setAttribute('d', majorSegments || 'M 0 0');
+    }
+    function updateGridMajorStride() {
+        const meters = Number.isFinite(state.gridStepMeters) && state.gridStepMeters > 0
+            ? state.gridStepMeters
+            : CONST.GRID;
+        const stride = Math.max(1, Math.round(1 / meters));
+        gridRenderState.majorStride = Math.min(50, stride);
+    }
+    function updateGridViewport() {
+        if (!state.viewBox) return;
+        const rect = ensureGridRect();
+        if (rect) {
+            const { x, y, width, height } = state.viewBox;
+            const padding = Math.max(state.gridSize || 0, Math.min(width, height) * 0.1);
+            rect.setAttribute('x', roundTo(x - padding, 3).toString());
+            rect.setAttribute('y', roundTo(y - padding, 3).toString());
+            rect.setAttribute('width', roundTo(width + padding * 2, 3).toString());
+            rect.setAttribute('height', roundTo(height + padding * 2, 3).toString());
+        }
+        renderGridLines();
+    }
     function applyGridPatternSize(sizePx) {
         if (!Number.isFinite(sizePx) || sizePx <= 0) return;
         const normalized = Math.round(sizePx * 1000) / 1000;
@@ -1029,6 +1152,7 @@
         dom.gridPattern.setAttribute('height', w);
         const path = dom.gridPattern.querySelector('path');
         path?.setAttribute('d', `M ${w} 0 L 0 0 0 ${w}`);
+        updateGridViewport();
     }
     function updateGridSize({ silent = false, deferInvalid = false } = {}) {
         if (!dom.gridSelect) return;
@@ -1095,6 +1219,8 @@
             state.gridStepMeters = commitMeters;
         }
 
+        updateGridMajorStride();
+
         if (!silent && !deferInvalid) {
             const messageMeters = state.gridStepMeters;
             const formatted = messageMeters.toLocaleString('ru-RU', {
@@ -1113,6 +1239,7 @@
     function updateViewBox() {
         if (!state.viewBox) return;
         dom.svg.setAttribute('viewBox', `${state.viewBox.x} ${state.viewBox.y} ${state.viewBox.width} ${state.viewBox.height}`);
+        updateGridViewport();
     }
     function startPan(e) {
         if (!state.viewBox) {
@@ -2438,7 +2565,9 @@
             width: dom.svg.viewBox.baseVal.width,
             height: dom.svg.viewBox.baseVal.height
         };
-        
+
+        updateGridViewport();
+
         // Load saved data robustly
         try {
             const saved = localStorage.getItem(LOCAL_STORAGE_KEY);

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
                             <feDropShadow dx="0" dy="4" stdDeviation="4" flood-color="#000000" flood-opacity="0.1"/>
                         </filter>
                         <pattern id="grid" width="50" height="50" patternUnits="userSpaceOnUse">
-                            <path d="M 50 0 L 0 0 0 50" fill="none" stroke="#e9ecef" stroke-width="1"/>
+                            <path d="M 50 0 L 0 0 0 50" fill="none" stroke="#e9ecef" stroke-width="1" vector-effect="non-scaling-stroke" shape-rendering="crispEdges"/>
                         </pattern>
                         <marker id="dim-arrow" viewBox="0 0 10 10" refX="1" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
                             <path d="M0 0L10 5L0 10z" fill="#aaa" />
@@ -177,7 +177,8 @@
                     </defs>
                     <rect width="100%" height="100%" class="floor"/>
                     <g id="grid-layer" pointer-events="none">
-                        <rect width="100%" height="100%" fill="url(#grid)" opacity="0.7"/>
+                        <rect id="grid-surface" width="100%" height="100%" fill="none" opacity="1"/>
+                        <g id="grid-lines" aria-hidden="true"></g>
                     </g>
                     <g id="underlay-layer"></g>
                     <g id="walls-layer"></g>


### PR DESCRIPTION
## Summary
- replace the pattern-based background with generated grid line paths so the grid always covers the current viewBox while zooming or panning
- adjust the grid overlay bounds and major line cadence whenever the grid step changes to keep the mesh readable

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd4fe916d88333a8403d98e0160dbe