### PR TITLE
Refine wall thickness rendering and template transforms

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,6 +18,11 @@
         },
     };
     const LOCAL_STORAGE_KEY = 'layout-v10-pro'; // Incremented version to avoid loading old potentially corrupt data
+    const SVG_NS = 'http://www.w3.org/2000/svg';
+    const PLAN_SCALE = 50; // 1:50 чертёжный масштаб
+    const EDGE_WIDTH_MM = 0.6; // толщина верхнего штриха в мм на листе
+    const MM_PER_METER = 1000;
+    const SHEET_MM_PER_METER = MM_PER_METER / PLAN_SCALE; // 20 мм на листе на каждый метр в реальности
     const dom = {
         svg: document.getElementById('svg'),
         itemsContainer: document.getElementById('items-layer'),
@@ -52,6 +57,7 @@
         btnAnalysis: document.getElementById('btnAnalysis'),
         btnCsv: document.getElementById('btnCsv'),
         btnTemplate: document.getElementById('btnTemplate'),
+        btnClearHost: document.getElementById('btnClearHost'),
         gridSelect: document.getElementById('gridStep'),
         snapGuidesEl: document.getElementById('snapGuides'),
         toolPointer: document.getElementById('tool-pointer'),
@@ -81,6 +87,8 @@
         rateFinish: document.getElementById('rate-finish'),
         ratePerimeter: document.getElementById('rate-perimeter'),
         rateEngineering: document.getElementById('rate-engineering'),
+        defs: document.querySelector('#svg defs'),
+        wallMaskTemplate: document.getElementById('wallOpeningsMask'),
     };
     const state = {
         selectedObject: null,
@@ -92,6 +100,7 @@
         gridStepMeters: CONST.GRID,
         gridSize: 50 * CONST.GRID,
         history: { stack: [], idx: -1, lock: false },
+        renderMode: 'schematic',
         activeTool: 'pointer',
         currentWallPoints: [],
         defaultWallType: 'structural',
@@ -126,17 +135,46 @@
     const wallIdMap = new Map();
     const componentStore = new Map();
     const componentIdMap = new Map();
+    const wallMaskMap = new Map();
     const WALL_TYPES = [
         { id: 'structural', label: 'Капитальная', description: 'Несущая стена, толщина ~250 мм' },
         { id: 'partition', label: 'Перегородка', description: 'Лёгкая перегородка, толщина ~100 мм' },
         { id: 'glass', label: 'Стеклянная', description: 'Витраж или стеклянная перегородка' },
         { id: 'half', label: 'Полустена', description: 'Парапет, барная стойка или ограждение' }
     ];
-    const WALL_STYLE_MAP = {
-        structural: { stroke: '#343a40', width: 16, dasharray: null, linecap: 'round' },
-        partition: { stroke: '#868e96', width: 10, dasharray: '28 12', linecap: 'butt' },
-        glass: { stroke: 'rgba(77,171,247,.9)', width: 8, dasharray: '12 8', linecap: 'butt' },
-        half: { stroke: '#adb5bd', width: 8, dasharray: '6 8', linecap: 'butt' },
+    const WALL_RENDER_PRESETS = {
+        structural: {
+            thickness: 0.25,
+            bodyStroke: 'rgba(15,46,43,0.35)',
+            edgeStroke: '#0F2E2B',
+            bodyDashMm: null,
+            edgeDashMm: null,
+        },
+        partition: {
+            thickness: 0.15,
+            bodyStroke: 'rgba(15,46,43,0.25)',
+            edgeStroke: '#0F2E2B',
+            bodyDashMm: null,
+            edgeDashMm: [6, 3.2],
+        },
+        glass: {
+            thickness: 0.1,
+            bodyStroke: 'rgba(77,171,247,0.32)',
+            edgeStroke: '#2F7EBB',
+            bodyDashMm: null,
+            edgeDashMm: [5, 3],
+        },
+        half: {
+            thickness: 0.1,
+            bodyStroke: 'rgba(15,46,43,0.18)',
+            edgeStroke: '#0F2E2B',
+            bodyDashMm: [4, 3],
+            edgeDashMm: [4, 4],
+        },
+    };
+    const OPENING_SPECS = {
+        door: { widthMeters: 0.9, stroke: '#8B4513' },
+        window: { widthMeters: 1.2, stroke: '#2F7EBB', fill: 'rgba(163,213,255,0.55)' },
     };
     const ESTIMATE_PRESETS = {
         standard: { finish: 50, perimeter: 12, engineering: 35 },
@@ -152,6 +190,26 @@
         clamp: (v, min, max) => Math.max(min, Math.min(max, v)),
         rafThrottle(fn) { let r = null, lastArgs = null; return function (...args) { lastArgs = args; if (r) return; r = requestAnimationFrame(() => { fn(...lastArgs); r = null; }); } }
     };
+    const KEY_CODE_MAP = {
+        v: 'KeyV',
+        w: 'KeyW',
+        d: 'KeyD',
+        o: 'KeyO',
+        m: 'KeyM',
+        z: 'KeyZ',
+        y: 'KeyY',
+        c: 'KeyC',
+        r: 'KeyR',
+        f: 'KeyF',
+        b: 'KeyB'
+    };
+    function matchesKey(e, letter) {
+        if (!letter) return false;
+        const lower = typeof e.key === 'string' ? e.key.toLowerCase() : '';
+        if (lower === letter) return true;
+        const expected = KEY_CODE_MAP[letter];
+        return expected ? e.code === expected : false;
+    }
 
     // === ИКОНКИ ДЛЯ КНОПОК ПАНЕЛЕЙ ===
     function attachPanelIcons(root = document) {
@@ -160,7 +218,9 @@
             if (btn.dataset.iconMounted === '1') return;
 
             const iconId = btn.getAttribute('data-icon');
-            const labelText = btn.textContent.trim();
+            const iconOnly = btn.hasAttribute('data-icon-only');
+            const labelAttr = btn.getAttribute('data-icon-label');
+            const labelText = labelAttr != null ? labelAttr : btn.textContent.trim();
 
             btn.textContent = '';
             const iconSpan = document.createElement('span');
@@ -168,12 +228,20 @@
             iconSpan.setAttribute('aria-hidden', 'true');
             iconSpan.innerHTML = `<svg viewBox="0 0 24 24" focusable="false"><use href="#${iconId}"></use></svg>`;
 
-            const labelSpan = document.createElement('span');
-            labelSpan.className = 'label';
-            labelSpan.textContent = labelText;
+            if (iconOnly) {
+                btn.classList.add('icon-only');
+                btn.appendChild(iconSpan);
+                if (!btn.hasAttribute('aria-label') && labelText) {
+                    btn.setAttribute('aria-label', labelText);
+                }
+            } else {
+                btn.prepend(iconSpan);
+                const labelSpan = document.createElement('span');
+                labelSpan.className = 'label';
+                labelSpan.textContent = labelText;
+                btn.appendChild(labelSpan);
+            }
 
-            btn.prepend(iconSpan);
-            btn.appendChild(labelSpan);
             btn.dataset.iconMounted = '1';
         });
     }
@@ -538,7 +606,25 @@
     // --- DATA & MODEL ---
     function getModel(el) { if (!el || !el.dataset) return {}; return { id: el.dataset.id, tpl: el.dataset.template || 'zone', x: +el.dataset.x || 0, y: +el.dataset.y || 0, a: +el.dataset.a || 0, sx: +el.dataset.sx || 1, sy: +el.dataset.sy || 1, cx: +el.dataset.cx || 0, cy: +el.dataset.cy || 0, ow: +el.dataset.ow || 0, oh: +el.dataset.oh || 0, locked: el.dataset.locked === 'true', visible: el.dataset.visible !== 'false' }; }
     function setModel(el, model) { for (const k in model) { if (model[k] !== undefined) el.dataset[k] = model[k]; } applyTransformFromDataset(el); updatePropertiesPanel(model); updateLayerItem(model); }
-    function applyTransformFromDataset(el) { const m = getModel(el); el.setAttribute('transform', `translate(${m.x}, ${m.y}) rotate(${m.a})`); const core = el.querySelector('.core'); if (core) { core.setAttribute('transform', `translate(${-m.cx}, ${-m.cy}) scale(${m.sx}, ${m.sy})`); } updateSelectionUI(el); }
+    function applyTransformFromDataset(el) {
+        const m = getModel(el);
+        // позиция и поворот всего объекта (контейнер)
+        el.setAttribute('transform', `translate(${m.x}, ${m.y}) rotate(${m.a})`);
+
+        const core = el.querySelector('.core');
+        if (core) {
+            if (!core.dataset.baseTransform) {
+                const init = core.getAttribute('transform') || '';
+                core.dataset.baseTransform = init.trim();
+            }
+            const base = core.dataset.baseTransform;
+            const dyn = `translate(${-m.cx}, ${-m.cy}) scale(${m.sx}, ${m.sy})`.trim();
+            const combined = [dyn, base].filter(Boolean).join(' ');
+            core.setAttribute('transform', combined);
+        }
+
+        updateSelectionUI(el);
+    }
 
     // --- UI & SELECTION ---
     function updateSelectionUI(el) { if (!el) return; const m = getModel(el); const w = m.ow * m.sx, h = m.oh * m.sy; const sel = el.querySelector('.selection-box'); if (sel) { sel.setAttribute('x', -w / 2 - 5); sel.setAttribute('y', -h / 2 - 5); sel.setAttribute('width', w + 10); sel.setAttribute('height', h + 10); } const rs = el.querySelector('.resize-handle'); if (rs) { rs.setAttribute('x', w / 2 - 6); rs.setAttribute('y', h / 2 - 6); } const ro = el.querySelector('.rotate-handle'); if (ro) { ro.setAttribute('cx', 0); ro.setAttribute('cy', -h / 2 - 20); } }
@@ -718,10 +804,12 @@
         model.components.forEach(comp => {
             const compEl = componentIdMap.get(comp.id);
             if (!compEl) return;
+            compEl.innerHTML = renderWallComponentMarkup(comp, model);
             const { point, angle } = pointAtWallDistance(model, comp.distance);
             const transform = `translate(${point.x}, ${point.y}) rotate(${angle})`;
             compEl.setAttribute('transform', transform);
         });
+        updateWallMaskOpenings(wallEl);
     }
 
     function updateWallHandles(wallEl) {
@@ -785,45 +873,211 @@
         return Math.min(...candidates);
     }
 
-    function updateWallStrokeWidth(path, basePx, scale) {
-        if (!path) return;
-        const resolvedBase = Number(basePx);
-        if (Number.isFinite(resolvedBase) && resolvedBase > 0) {
-            path.dataset.strokeBasePx = String(resolvedBase);
+    function getPixelsPerMeter() {
+        const ppm = Number.isFinite(state.pixelsPerMeter) && state.pixelsPerMeter > 0 ? state.pixelsPerMeter : 50;
+        return ppm;
+    }
+
+    function sheetMmToUnits(mm) {
+        if (!Number.isFinite(mm)) return 0;
+        const ppm = getPixelsPerMeter();
+        return (mm * ppm) / SHEET_MM_PER_METER;
+    }
+
+    function getWallPreset(type) {
+        const resolved = ensureWallType(type);
+        return WALL_RENDER_PRESETS[resolved] || WALL_RENDER_PRESETS.structural;
+    }
+
+    function resolveWallThickness(model, preset) {
+        const resolvedPreset = preset || getWallPreset(model?.type);
+        const customThickness = model?.thickness;
+        const thicknessMeters = Number.isFinite(customThickness) && customThickness > 0
+            ? customThickness
+            : resolvedPreset.thickness;
+        const thicknessSheetMm = thicknessMeters * SHEET_MM_PER_METER;
+        const thicknessUnits = sheetMmToUnits(thicknessSheetMm);
+        return {
+            thicknessMeters,
+            thicknessSheetMm,
+            thicknessUnits,
+            preset: resolvedPreset,
+        };
+    }
+
+    function ensureWallMask(wallEl) {
+        if (!wallEl) return null;
+        const baseId = wallEl.dataset.id ? `wall-mask-${wallEl.dataset.id}` : `wall-mask-${wallMaskMap.size + 1}`;
+        let entry = wallMaskMap.get(wallEl);
+        if (entry) {
+            if (entry.id !== baseId) {
+                entry.id = baseId;
+                entry.mask.setAttribute('id', baseId);
+            }
+            return entry;
         }
-        const base = Number(path.dataset.strokeBasePx);
-        if (!Number.isFinite(base) || base <= 0) return;
-        const effectiveScale = Number.isFinite(scale) && scale > 0 ? scale : getSvgDisplayScale();
-        if (!Number.isFinite(effectiveScale) || effectiveScale <= 0) return;
-        const unitsWidth = base / effectiveScale;
-        if (Number.isFinite(unitsWidth) && unitsWidth > 0) {
-            path.setAttribute('stroke-width', `${unitsWidth}`);
-            path.style.strokeWidth = '';
+        let maskEl;
+        let openingsGroup;
+        if (dom.wallMaskTemplate) {
+            maskEl = dom.wallMaskTemplate.cloneNode(true);
+            maskEl.removeAttribute('id');
+            openingsGroup = maskEl.querySelector('[data-role="wall-mask-openings"]');
+            if (openingsGroup) {
+                openingsGroup.innerHTML = '';
+            }
+        }
+        if (!maskEl) {
+            maskEl = document.createElementNS(SVG_NS, 'mask');
+            const rect = document.createElementNS(SVG_NS, 'rect');
+            rect.setAttribute('x', '-10000');
+            rect.setAttribute('y', '-10000');
+            rect.setAttribute('width', '20000');
+            rect.setAttribute('height', '20000');
+            rect.setAttribute('fill', 'white');
+            maskEl.appendChild(rect);
+        }
+        if (!openingsGroup) {
+            openingsGroup = document.createElementNS(SVG_NS, 'g');
+            openingsGroup.dataset.role = 'wall-mask-openings';
+            maskEl.appendChild(openingsGroup);
+        }
+        maskEl.setAttribute('id', baseId);
+        maskEl.setAttribute('maskUnits', 'userSpaceOnUse');
+        maskEl.setAttribute('maskContentUnits', 'userSpaceOnUse');
+        dom.defs?.appendChild(maskEl);
+        entry = { id: baseId, mask: maskEl, openingsGroup };
+        wallMaskMap.set(wallEl, entry);
+        return entry;
+    }
+
+    function ensureWallPath(wallEl, className) {
+        if (!wallEl) return null;
+        let path = wallEl.querySelector(`.${className}`);
+        if (path) return path;
+        path = document.createElementNS(SVG_NS, 'path');
+        path.classList.add(className);
+        if (className === 'wall-body') {
+            wallEl.insertBefore(path, wallEl.firstChild || null);
+        } else if (className === 'wall-edge') {
+            const handles = wallEl.querySelector('.wall-handles');
+            if (handles) {
+                wallEl.insertBefore(path, handles);
+            } else {
+                const inserts = wallEl.querySelector('.wall-inserts');
+                if (inserts) {
+                    wallEl.insertBefore(path, inserts);
+                } else {
+                    wallEl.appendChild(path);
+                }
+            }
+        } else {
+            wallEl.appendChild(path);
+        }
+        return path;
+    }
+
+    function setStrokeDash(path, dashMm) {
+        if (!path) return;
+        if (Array.isArray(dashMm) && dashMm.length) {
+            const values = dashMm.map(v => sheetMmToUnits(v)).filter(v => Number.isFinite(v) && v > 0);
+            if (values.length) {
+                path.setAttribute('stroke-dasharray', values.map(v => v.toFixed(3)).join(' '));
+                return;
+            }
+        }
+        path.removeAttribute('stroke-dasharray');
+    }
+
+    function updateWallVisualStyle(wallEl, model = getWallModel(wallEl)) {
+        if (!wallEl || !model) return;
+        const preset = getWallPreset(model.type);
+        const thickness = resolveWallThickness(model, preset);
+        model.thickness = thickness.thicknessMeters;
+        const body = wallEl.querySelector('.wall-body');
+        const edge = wallEl.querySelector('.wall-edge');
+        if (body) {
+            body.setAttribute('stroke', preset.bodyStroke);
+            if (thickness.thicknessUnits > 0) {
+                body.setAttribute('stroke-width', thickness.thicknessUnits.toFixed(3));
+                body.dataset.sheetThicknessMm = thickness.thicknessSheetMm.toFixed(2);
+            } else {
+                body.removeAttribute('stroke-width');
+                delete body.dataset.sheetThicknessMm;
+            }
+            body.setAttribute('stroke-linecap', 'butt');
+            body.setAttribute('stroke-linejoin', 'round');
+            body.setAttribute('fill', 'none');
+            setStrokeDash(body, preset.bodyDashMm);
+        }
+        if (edge) {
+            edge.setAttribute('stroke', preset.edgeStroke || '#0F2E2B');
+            const edgeWidth = sheetMmToUnits(EDGE_WIDTH_MM);
+            if (edgeWidth > 0) {
+                edge.setAttribute('stroke-width', edgeWidth.toFixed(3));
+            } else {
+                edge.removeAttribute('stroke-width');
+            }
+            edge.setAttribute('stroke-linecap', 'butt');
+            edge.setAttribute('stroke-linejoin', 'round');
+            edge.setAttribute('fill', 'none');
+            setStrokeDash(edge, preset.edgeDashMm);
         }
     }
 
-    function refreshWallStrokeWidths() {
-        const scale = getSvgDisplayScale();
-        if (!Number.isFinite(scale) || scale <= 0) return;
-        dom.wallsContainer?.querySelectorAll('.wall path').forEach(path => {
-            updateWallStrokeWidth(path, Number(path.dataset.strokeBasePx), scale);
+    function updateWallMaskOpenings(wallEl) {
+        if (!wallEl) return;
+        const model = getWallModel(wallEl);
+        if (!model) return;
+        const entry = ensureWallMask(wallEl);
+        if (!entry) return;
+        entry.openingsGroup.innerHTML = '';
+        const body = wallEl.querySelector('.wall-body');
+        if (body) {
+            body.setAttribute('mask', `url(#${entry.id})`);
+        }
+        if (!Array.isArray(model.components) || !model.components.length) return;
+        const thickness = resolveWallThickness(model);
+        const thicknessUnits = thickness.thicknessUnits;
+        if (!(thicknessUnits > 0)) return;
+        const halfThickness = thicknessUnits / 2;
+        model.components.forEach(comp => {
+            const spec = OPENING_SPECS[comp.type] || OPENING_SPECS.door;
+            let widthMeters = Number.isFinite(comp.width) && comp.width > 0 ? comp.width : spec.widthMeters;
+            if (!Number.isFinite(widthMeters) || widthMeters <= 0) {
+                widthMeters = spec.widthMeters;
+            }
+            const widthSheetMm = widthMeters * SHEET_MM_PER_METER;
+            const widthUnits = sheetMmToUnits(widthSheetMm);
+            if (!(widthUnits > 0)) return;
+            const { point, angle } = pointAtWallDistance(model, comp.distance);
+            const openingRect = document.createElementNS(SVG_NS, 'rect');
+            openingRect.setAttribute('x', (-widthUnits / 2).toFixed(3));
+            openingRect.setAttribute('y', (-halfThickness).toFixed(3));
+            openingRect.setAttribute('width', widthUnits.toFixed(3));
+            openingRect.setAttribute('height', thicknessUnits.toFixed(3));
+            openingRect.setAttribute('fill', 'black');
+            openingRect.setAttribute('transform', `translate(${point.x}, ${point.y}) rotate(${angle})`);
+            entry.openingsGroup.appendChild(openingRect);
         });
     }
 
-    function applyWallStrokeStyle(path, type) {
-        if (!path) return;
-        const style = WALL_STYLE_MAP[type] || WALL_STYLE_MAP.structural;
-        path.setAttribute('fill', 'none');
-        path.setAttribute('stroke', style.stroke);
-        path.setAttribute('stroke-linejoin', 'round');
-        path.setAttribute('stroke-linecap', style.linecap || 'round');
-        if (style.dasharray) {
-            path.setAttribute('stroke-dasharray', style.dasharray);
-        } else {
-            path.removeAttribute('stroke-dasharray');
-        }
-        path.removeAttribute('vector-effect');
-        updateWallStrokeWidth(path, style.width);
+    function refreshWallStrokeWidths() {
+        const walls = dom.wallsContainer?.querySelectorAll('.wall');
+        if (!walls) return;
+        walls.forEach(wall => {
+            const model = getWallModel(wall);
+            if (!model) return;
+            updateWallVisualStyle(wall, model);
+            if (Array.isArray(model.components)) {
+                model.components.forEach(comp => {
+                    const compEl = componentIdMap.get(comp.id);
+                    if (compEl) {
+                        compEl.innerHTML = renderWallComponentMarkup(comp, model);
+                    }
+                });
+            }
+            updateWallMaskOpenings(wall);
+        });
     }
 
     function updateWallElementGeometry(wallEl) {
@@ -832,12 +1086,16 @@
         const resolvedType = ensureWallType(model.type || state.defaultWallType);
         model.type = resolvedType;
         wallEl.dataset.type = resolvedType;
-        const path = wallEl.querySelector('path') || document.createElementNS('http://www.w3.org/2000/svg', 'path');
-        if (!path.parentNode) wallEl.appendChild(path);
-        applyWallStrokeStyle(path, resolvedType);
+        const bodyPath = ensureWallPath(wallEl, 'wall-body');
+        const edgePath = ensureWallPath(wallEl, 'wall-edge');
+        const maskEntry = ensureWallMask(wallEl);
+        if (maskEntry && bodyPath) {
+            bodyPath.setAttribute('mask', `url(#${maskEntry.id})`);
+        }
         const pts = model.points;
         if (!pts || pts.length === 0) {
-            path.removeAttribute('d');
+            bodyPath?.removeAttribute('d');
+            edgePath?.removeAttribute('d');
             return;
         }
         let d = `M ${pts[0].x} ${pts[0].y}`;
@@ -845,23 +1103,30 @@
             d += ` L ${pts[i].x} ${pts[i].y}`;
         }
         if (model.closed && pts.length > 2) d += ' Z';
-        path.setAttribute('d', d);
+        if (bodyPath) bodyPath.setAttribute('d', d);
+        if (edgePath) edgePath.setAttribute('d', d);
+        updateWallVisualStyle(wallEl, model);
         updateWallHandles(wallEl);
         updateWallComponentsPosition(wallEl);
     }
 
     function createWall(points, closed = false) {
         if (!points || points.length < 2) return null;
-        const wallEl = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const wallEl = document.createElementNS(SVG_NS, 'g');
         wallEl.classList.add('wall');
         const id = `wall-${++state.wallCounter}`;
         wallEl.dataset.id = id;
         const type = ensureWallType(state.defaultWallType);
         const model = { id, points: points.map(p => ({ x: p.x, y: p.y })), closed, components: [], type };
-        const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-        wallEl.appendChild(path);
+        const body = document.createElementNS(SVG_NS, 'path');
+        body.classList.add('wall-body');
+        const edge = document.createElementNS(SVG_NS, 'path');
+        edge.classList.add('wall-edge');
+        wallEl.appendChild(body);
+        wallEl.appendChild(edge);
         wallEl.dataset.type = type;
         dom.wallsContainer.appendChild(wallEl);
+        ensureWallMask(wallEl);
         registerWall(wallEl, model);
         return wallEl;
     }
@@ -901,6 +1166,11 @@
         }
         wallStore.delete(wallEl);
         wallIdMap.delete(model.id);
+        const maskEntry = wallMaskMap.get(wallEl);
+        if (maskEntry) {
+            maskEntry.mask.remove();
+            wallMaskMap.delete(wallEl);
+        }
         wallEl.remove();
         if (state.selectedWall === wallEl) {
             state.selectedWall = null;
@@ -972,7 +1242,7 @@
     function makeWallInteractive(wallEl) {
         if (wallEl.dataset.interactive === 'true') return;
         wallEl.dataset.interactive = 'true';
-        const path = wallEl.querySelector('path');
+        const path = wallEl.querySelector('.wall-edge') || wallEl.querySelector('.wall-body');
         if (path) {
             path.addEventListener('dblclick', e => {
                 if (state.activeTool !== 'pointer') return;
@@ -1007,7 +1277,153 @@
     }
 
     // --- OBJECT & WALL CREATION / MANIPULATION ---
-    function createLayoutObject(tpl, x, y) { const el = document.createElementNS('http://www.w3.org/2000/svg', 'g'); el.classList.add('layout-object'); el.dataset.id = `el-${state.objectCounter++}`; const safeTpl = ITEM_TEMPLATES[tpl] ? tpl : 'zone'; el.dataset.template = safeTpl; el.innerHTML = (ITEM_TEMPLATES[safeTpl].svg() + `<rect class="selection-box"></rect><rect class="resize-handle" width="12" height="12"></rect><circle class="rotate-handle" r="8"></circle>`); dom.itemsContainer.appendChild(el); const core = el.querySelector('.core'); const b = core.getBBox(); const model = { x, y, a: 0, sx: 1, sy: 1, cx: b.x + b.width / 2, cy: b.y + b.height / 2, ow: b.width, oh: b.height, locked: false, visible: true }; setModel(el, model); makeInteractive(el); commit('add'); return el; }
+    function buildAttributeString(attrs, extraClasses = []) {
+        const attrMap = new Map();
+        (attrs || []).forEach(attr => {
+            if (!attr || !attr.name) return;
+            attrMap.set(attr.name, attr.value ?? '');
+        });
+        const classNames = new Set((attrMap.get('class') || '').split(/\s+/).filter(Boolean));
+        extraClasses.forEach(cls => classNames.add(cls));
+        if (classNames.size) {
+            attrMap.set('class', Array.from(classNames).join(' '));
+        } else if (extraClasses.length) {
+            attrMap.set('class', extraClasses.join(' '));
+        }
+        return Array.from(attrMap.entries()).map(([name, value]) => `${name}="${value}"`).join(' ');
+    }
+
+    function renderItemTemplate(id, mode = state.renderMode || 'schematic') {
+        const tpl = ITEM_TEMPLATES?.[id];
+        if (!tpl) return '';
+        const variant = mode === 'rich' ? 'rich' : 'schematic';
+        if (variant === 'schematic' && typeof tpl.schematicSvg === 'function') {
+            if (tpl.__schematicSymbolId && tpl.__schematicAttrs) {
+                const attrString = buildAttributeString(tpl.__schematicAttrs, ['core', 'schematic-only']);
+                const symbolId = tpl.__schematicSymbolId;
+                return `<g ${attrString}><use href="#${symbolId}" xlink:href="#${symbolId}"></use></g>`;
+            }
+            const markup = tpl.schematicSvg();
+            if (markup) return markup;
+        }
+        return typeof tpl.svg === 'function' ? tpl.svg() : '';
+    }
+
+    function rerenderLayoutObject(el) {
+        if (!el) return;
+        const tplId = el.dataset?.template;
+        if (!tplId) return;
+        const markup = renderItemTemplate(tplId, state.renderMode);
+        if (!markup) return;
+        const currentCore = el.querySelector('.core');
+        if (currentCore) {
+            currentCore.outerHTML = markup;
+        } else {
+            el.insertAdjacentHTML('afterbegin', markup);
+        }
+        const newCore = el.querySelector('.core');
+        if (!newCore) return;
+        const bbox = newCore.getBBox();
+        const model = getModel(el);
+        model.cx = bbox.x + bbox.width / 2;
+        model.cy = bbox.y + bbox.height / 2;
+        model.ow = bbox.width;
+        model.oh = bbox.height;
+        setModel(el, model);
+    }
+
+    function rerenderAllLayoutObjects() {
+        if (!dom.itemsContainer) return;
+        dom.itemsContainer.querySelectorAll('.layout-object').forEach(rerenderLayoutObject);
+    }
+
+    function updateSvgModeClass(mode) {
+        if (!dom.svg) return;
+        dom.svg.classList.remove('svg-mode--schematic', 'svg-mode--rich');
+        dom.svg.classList.add(mode === 'rich' ? 'svg-mode--rich' : 'svg-mode--schematic');
+    }
+
+    function setRenderMode(mode, { rerender = true } = {}) {
+        const next = mode === 'rich' ? 'rich' : 'schematic';
+        const prev = state.renderMode;
+        state.renderMode = next;
+        updateSvgModeClass(next);
+        if (rerender && prev !== next) {
+            rerenderAllLayoutObjects();
+            commit('render_mode_change');
+        }
+        return next;
+    }
+
+    function buildSymbolsFromSchematic() {
+        if (!dom.svg || typeof ITEM_TEMPLATES !== 'object') return;
+        let defsHost = dom.svg.querySelector('defs[data-generated="schematic-symbols"]');
+        if (!defsHost) {
+            defsHost = document.createElementNS(SVG_NS, 'defs');
+            defsHost.dataset.generated = 'schematic-symbols';
+            dom.svg.prepend(defsHost);
+        } else {
+            while (defsHost.firstChild) defsHost.removeChild(defsHost.firstChild);
+        }
+        Object.entries(ITEM_TEMPLATES).forEach(([id, tpl]) => {
+            if (!tpl) return;
+            delete tpl.__schematicSymbolId;
+            delete tpl.__schematicAttrs;
+            if (typeof tpl.schematicSvg !== 'function') return;
+            const raw = tpl.schematicSvg();
+            if (typeof raw !== 'string' || !raw.trim()) return;
+            const temp = document.createElementNS(SVG_NS, 'svg');
+            temp.innerHTML = raw.trim();
+            const coreEl = temp.querySelector('.core');
+            if (!coreEl) return;
+            const attrs = Array.from(coreEl.attributes).map(attr => ({ name: attr.name, value: attr.value }));
+            const symbol = document.createElementNS(SVG_NS, 'symbol');
+            const symbolId = `sym-${id}`;
+            symbol.setAttribute('id', symbolId);
+            Array.from(coreEl.childNodes).forEach(node => {
+                symbol.appendChild(node.cloneNode(true));
+            });
+            defsHost.appendChild(symbol);
+            tpl.__schematicSymbolId = symbolId;
+            tpl.__schematicAttrs = attrs;
+        });
+    }
+
+    function createLayoutObject(tpl, x, y) {
+        const el = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        el.classList.add('layout-object');
+        el.dataset.id = `el-${state.objectCounter++}`;
+        const safeTpl = ITEM_TEMPLATES[tpl] ? tpl : 'zone';
+        el.dataset.template = safeTpl;
+        let coreMarkup = renderItemTemplate(safeTpl, state.renderMode);
+        if (!coreMarkup && typeof ITEM_TEMPLATES[safeTpl]?.svg === 'function') {
+            coreMarkup = ITEM_TEMPLATES[safeTpl].svg();
+        }
+        if (!coreMarkup) {
+            coreMarkup = `<g class="core" data-id="${safeTpl}"></g>`;
+        }
+        el.innerHTML = `${coreMarkup}<rect class="selection-box"></rect><rect class="resize-handle" width="12" height="12"></rect><circle class="rotate-handle" r="8"></circle>`;
+        dom.itemsContainer.appendChild(el);
+        const core = el.querySelector('.core');
+        const bbox = core ? core.getBBox() : { x: 0, y: 0, width: 0, height: 0 };
+        const model = {
+            x,
+            y,
+            a: 0,
+            sx: 1,
+            sy: 1,
+            cx: bbox.x + bbox.width / 2,
+            cy: bbox.y + bbox.height / 2,
+            ow: bbox.width,
+            oh: bbox.height,
+            locked: false,
+            visible: true
+        };
+        setModel(el, model);
+        makeInteractive(el);
+        commit('add');
+        return el;
+    }
     function makeInteractive(el) { interact(el).draggable({ onstart: () => { if (getModel(el).locked || state.activeTool !== 'pointer') return false; }, listeners: { move: utils.rafThrottle(e => { const m = getModel(el); const d = utils.screenDeltaToSVG(e.dx, e.dy); m.x += d.dx; m.y += d.dy; setModel(el, m); showGuidesIfNeeded(m); }), end: () => { snapSelectedToGrid(el); clearGuides(); commit('move'); } } }).resizable({ edges: { left: true, right: true, top: true, bottom: true }, onstart: () => { if (getModel(el).locked || state.activeTool !== 'pointer') return false; }, listeners: { move: utils.rafThrottle(e => { const m = getModel(el); const bw = Math.max(1, m.ow * m.sx), bh = Math.max(1, m.oh * m.sy); const dScr = utils.screenDeltaToSVG(e.delta.x || 0, e.delta.y || 0); const rad = m.a * Math.PI / 180, cos = Math.cos(rad), sin = Math.sin(rad); const dLoc = { lx: dScr.dx * cos + dScr.dy * sin, ly: -dScr.dx * sin + dScr.dy * cos }; let sx = m.sx, sy = m.sy; if (e.edges.left) sx = utils.clamp((bw - dLoc.lx) / m.ow, 0.1, 100); if (e.edges.right) sx = utils.clamp((bw + dLoc.lx) / m.ow, 0.1, 100); if (e.edges.top) sy = utils.clamp((bh - dLoc.ly) / m.oh, 0.1, 100); if (e.edges.bottom) sy = utils.clamp((bh + dLoc.ly) / m.oh, 0.1, 100); const ox = (e.edges.left ? m.ow / 2 : e.edges.right ? -m.ow / 2 : 0); const oy = (e.edges.top ? m.oh / 2 : e.edges.bottom ? -m.oh / 2 : 0); const dx = (m.sx - sx) * ox, dy = (m.sy - sy) * oy; m.x += dx * cos - dy * sin; m.y += dx * sin + dy * cos; m.sx = sx; m.sy = sy; setModel(el, m); }), end: () => { snapSelectedToGrid(el, true); commit('resize'); } } }); interact(el.querySelector('.rotate-handle')).draggable({ onstart: e => { if (getModel(el).locked || state.activeTool !== 'pointer') return false; e.interaction.el = el; }, listeners: { move: utils.rafThrottle(e => { const m = getModel(e.interaction.el); const p = utils.toSVGPoint(e.clientX, e.clientY); const ang = Math.atan2(p.y - m.y, p.x - m.x) * 180 / Math.PI + 90; m.a = state.isShiftHeld ? Math.round(ang / 15) * 15 : ang; setModel(e.interaction.el, m); }), end: () => { snapSelectedToGrid(el); commit('rotate'); } } }); }
     function updateFromProperties() { if (!state.selectedObject) return; const model = getModel(state.selectedObject); let changed = false; const props = { x: parseFloat(dom.propX.value), y: parseFloat(dom.propY.value), w: parseFloat(dom.propW.value), h: parseFloat(dom.propH.value), a: parseFloat(dom.propA.value) }; if (!isNaN(props.x) && model.x !== props.x) { model.x = props.x; changed = true; } if (!isNaN(props.y) && model.y !== props.y) { model.y = props.y; changed = true; } if (!isNaN(props.a)) { const newA = props.a % 360; if (model.a !== newA) { model.a = newA; changed = true; } } if (!isNaN(props.w) && props.w > 0) { const newSx = props.w / model.ow; if (model.sx !== newSx) { model.sx = newSx; changed = true; } } if (!isNaN(props.h) && props.h > 0) { const newSy = props.h / model.oh; if (model.sy !== newSy) { model.sy = newSy; changed = true; } } if (changed) { setModel(state.selectedObject, model); commit('props_update'); } updatePropertiesPanel(model); }
     function toggleTool(tool) {
@@ -1056,6 +1472,42 @@
         hideWallLengthPreview();
         clearSnapMarkers();
     }
+    function renderWallComponentMarkup(compModel, wallModel) {
+        if (!compModel) return '';
+        const spec = OPENING_SPECS[compModel.type] || OPENING_SPECS.door;
+        const wallPreset = getWallPreset(wallModel?.type || state.defaultWallType);
+        const thickness = resolveWallThickness(wallModel, wallPreset);
+        let thicknessUnits = thickness.thicknessUnits;
+        if (!(thicknessUnits > 0)) {
+            thicknessUnits = sheetMmToUnits(wallPreset.thickness * SHEET_MM_PER_METER);
+        }
+        const halfThickness = thicknessUnits / 2;
+        let widthMeters = Number.isFinite(compModel.width) && compModel.width > 0 ? compModel.width : spec.widthMeters;
+        if (!Number.isFinite(widthMeters) || widthMeters <= 0) {
+            widthMeters = spec.widthMeters;
+        }
+        const widthSheetMm = widthMeters * SHEET_MM_PER_METER;
+        const widthUnits = sheetMmToUnits(widthSheetMm);
+        const strokeWidth = Math.max(sheetMmToUnits(0.35), 0.8);
+        if (compModel.type === 'door') {
+            const radius = widthUnits / 2;
+            const stroke = spec.stroke || '#8B4513';
+            const safeHalfThickness = halfThickness || sheetMmToUnits(4) / 2;
+            const arcEndX = radius;
+            const arcEndY = safeHalfThickness - radius;
+            return `
+                <line x1="${(-radius).toFixed(3)}" y1="${safeHalfThickness.toFixed(3)}" x2="${(-radius).toFixed(3)}" y2="${(-safeHalfThickness).toFixed(3)}" stroke="${stroke}" stroke-width="${strokeWidth.toFixed(3)}" vector-effect="non-scaling-stroke" stroke-linecap="round"/>
+                <path d="M ${(-radius).toFixed(3)} ${safeHalfThickness.toFixed(3)} A ${radius.toFixed(3)} ${radius.toFixed(3)} 0 0 1 ${arcEndX.toFixed(3)} ${arcEndY.toFixed(3)}" fill="none" stroke="${stroke}" stroke-width="${strokeWidth.toFixed(3)}" vector-effect="non-scaling-stroke" stroke-linecap="round"/>
+            `;
+        }
+        const stroke = spec.stroke || '#2F7EBB';
+        const fill = spec.fill || 'rgba(163,213,255,0.55)';
+        const barHeight = Math.max(sheetMmToUnits(1.2), thicknessUnits * 0.6 || sheetMmToUnits(1.2));
+        return `
+            <rect x="${(-widthUnits / 2).toFixed(3)}" y="${(-barHeight / 2).toFixed(3)}" width="${widthUnits.toFixed(3)}" height="${barHeight.toFixed(3)}" fill="${fill}" stroke="${stroke}" stroke-width="${strokeWidth.toFixed(3)}" vector-effect="non-scaling-stroke" rx="${sheetMmToUnits(0.5).toFixed(3)}" />
+            <line x1="${(-widthUnits / 2).toFixed(3)}" y1="0" x2="${(widthUnits / 2).toFixed(3)}" y2="0" stroke="${stroke}" stroke-width="${strokeWidth.toFixed(3)}" vector-effect="non-scaling-stroke" />
+        `;
+    }
     function placeWallComponent(type, placement) {
         const wallEl = ensureWallElement(placement?.wallEl || (state.pendingComponentPlacement?.wallEl));
         const wallModel = getWallModel(wallEl);
@@ -1063,18 +1515,24 @@
             utils.showToast('Не удалось определить стену для проёма');
             return null;
         }
-        const el = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+        const el = document.createElementNS(SVG_NS, 'g');
         el.classList.add('wall-component');
         const id = `comp-${++state.componentCounter}`;
         el.dataset.id = id;
         el.dataset.type = type;
         el.dataset.wallId = wallModel.id;
-        const width = type === 'door' ? 80 : 120;
-        const mask = `<rect x="-${width / 2}" y="-11" width="${width}" height="22" fill="#fdfdfd" />`;
-        const visual = type === 'door'
-            ? `<path d="M -40 0 A 40 40 0 0 1 0 -40" stroke="#8B4513" stroke-width="2" fill="none"/><line x1="-40" y1="0" x2="-40" y2="-5" stroke="#8B4513" stroke-width="2"/>`
-            : `<rect x="-60" y="-5.5" width="120" height="11" fill="#a3d5ff" stroke="#5b9ad4" stroke-width="2" />`;
-        el.innerHTML = mask + visual;
+        const spec = OPENING_SPECS[type] || OPENING_SPECS.door;
+        let widthMeters = placement?.width;
+        if (typeof widthMeters === 'string') {
+            widthMeters = parseFloat(widthMeters.replace(/,/g, '.'));
+        }
+        widthMeters = Number.isFinite(widthMeters) ? widthMeters : spec.widthMeters;
+        if (Number.isFinite(widthMeters) && widthMeters > 10) {
+            widthMeters = widthMeters / getPixelsPerMeter();
+        }
+        if (!Number.isFinite(widthMeters) || widthMeters <= 0) {
+            widthMeters = spec.widthMeters;
+        }
         dom.wallComponentsContainer.appendChild(el);
         const distanceAlong = placement?.distance ?? state.pendingComponentPlacement?.distance ?? 0;
         const initialPoint = placement?.point || state.pendingComponentPlacement?.point;
@@ -1083,7 +1541,11 @@
             const ang = initialAngle ?? 0;
             el.setAttribute('transform', `translate(${initialPoint.x}, ${initialPoint.y}) rotate(${ang})`);
         }
-        const compModel = { id, type, wallId: wallModel.id, distance: distanceAlong, offset: 0 };
+        const compModel = { id, type, wallId: wallModel.id, distance: distanceAlong, offset: 0, width: widthMeters };
+        el.innerHTML = renderWallComponentMarkup(compModel, wallModel);
+        if (Number.isFinite(widthMeters)) {
+            el.dataset.width = widthMeters.toFixed(3);
+        }
         componentStore.set(el, compModel);
         componentIdMap.set(id, el);
         if (!Array.isArray(wallModel.components)) wallModel.components = [];
@@ -1953,6 +2415,42 @@
             }
         }
     }
+    function hasLayoutContent() {
+        const hasObjects = !!dom.itemsContainer?.querySelector('.layout-object');
+        const hasWalls = (dom.wallsContainer?.childElementCount || 0) > 0;
+        const hasComponents = (dom.wallComponentsContainer?.childElementCount || 0) > 0;
+        const hasPreviews = (dom.previewsContainer?.childElementCount || 0) > 0;
+        const hasMeasurements = Array.isArray(state.measurements) && state.measurements.length > 0;
+        const hasMeasureDraft = Array.isArray(state.measurePoints) && state.measurePoints.length > 0;
+        return hasObjects || hasWalls || hasComponents || hasPreviews || hasMeasurements || hasMeasureDraft;
+    }
+    function clearHost(confirmPrompt = true) {
+        if (!hasLayoutContent()) {
+            return false;
+        }
+        const message = 'Очистить текущий план? Все стены, объекты, проёмы и измерения будут удалены.';
+        if (confirmPrompt && !window.confirm(message)) {
+            return false;
+        }
+
+        state.currentWallPoints = [];
+        if (dom.wallPreview) {
+            dom.wallPreview.setAttribute('points', '');
+        }
+        dom.previewsContainer.innerHTML = '';
+        hideWallLengthPreview();
+        state.measurePoints = [];
+
+        restore({ items: [], walls: [], components: [], measurements: [] });
+        resetMeasurementPreview();
+        if (dom.ctx) {
+            dom.ctx.style.display = 'none';
+        }
+        commit('clear_host');
+        utils.showToast('План очищен');
+        return true;
+    }
+
     function loadMasterProject() {
         try {
             // подтверждение для перезаписи текущего проекта
@@ -2071,6 +2569,7 @@
     // --- HISTORY (UNDO/REDO) ---
     function snapshot() {
         return {
+            view: { mode: state.renderMode },
             items: Array.from(dom.itemsContainer.children).filter(n => n.classList.contains('layout-object')).map(getModel),
             walls: Array.from(wallStore.values()).map(model => ({
                 id: model.id,
@@ -2083,7 +2582,8 @@
                 type: comp.type,
                 wallId: comp.wallId,
                 distance: comp.distance,
-                offset: comp.offset || 0
+                offset: comp.offset || 0,
+                width: comp.width
             })),
             wallDefaults: { type: state.defaultWallType },
             grid: {
@@ -2105,6 +2605,8 @@
     function restore(data) {
         state.history.lock = true;
 
+        setRenderMode(data?.view?.mode, { rerender: false });
+
         Array.from(dom.itemsContainer.children).slice().forEach(n => {
             if (n.classList.contains('layout-object')) {
                 interact(n).unset();
@@ -2112,6 +2614,8 @@
             }
         });
 
+        wallMaskMap.forEach(entry => entry.mask.remove());
+        wallMaskMap.clear();
         dom.wallsContainer.innerHTML = '';
         wallStore.clear();
         wallIdMap.clear();
@@ -2241,7 +2745,7 @@
             }
             const wallEl = wallIdMap.get(c.wallId);
             if (!wallEl) return;
-            const compEl = placeWallComponent(c.type, { wallEl, distance: c.distance || 0 });
+            const compEl = placeWallComponent(c.type, { wallEl, distance: c.distance || 0, width: c.width });
             const compModel = componentStore.get(compEl);
             if (!compModel) return;
             const originalId = compModel.id;
@@ -2250,12 +2754,23 @@
                 compEl.dataset.id = c.id;
             }
             compModel.offset = c.offset || 0;
+            const wallModel = getWallModel(wallEl);
+            if (Number.isFinite(c.width) && c.width > 0) {
+                let widthMeters = c.width;
+                if (widthMeters > 10) {
+                    widthMeters = widthMeters / getPixelsPerMeter();
+                }
+                compModel.width = widthMeters;
+                compEl.dataset.width = widthMeters.toFixed(3);
+                if (wallModel) {
+                    compEl.innerHTML = renderWallComponentMarkup(compModel, wallModel);
+                }
+            }
             componentStore.set(compEl, compModel);
             if (originalId && originalId !== compModel.id) {
                 componentIdMap.delete(originalId);
             }
             componentIdMap.set(compModel.id, compEl);
-            const wallModel = getWallModel(wallEl);
             if (wallModel) {
                 wallModel.components = wallModel.components || [];
                 if (!wallModel.components.includes(compModel)) wallModel.components.push(compModel);
@@ -2325,56 +2840,56 @@
 
         // Горячие клавиши для переключения инструмента (без модификаторов)
         if (!e.ctrlKey && !e.metaKey && !e.altKey) {
-            switch (e.key.toLowerCase()) {
-                case 'v': toggleTool('pointer'); e.preventDefault(); return;
-                case 'w': toggleTool('wall'); e.preventDefault(); return;
-                case 'd': toggleTool('door'); e.preventDefault(); return;
-                case 'o': toggleTool('window'); e.preventDefault(); return;
-                case 'm': toggleTool('measure'); e.preventDefault(); return;
-            }
+            if (matchesKey(e, 'v')) { toggleTool('pointer'); e.preventDefault(); return; }
+            if (matchesKey(e, 'w')) { toggleTool('wall'); e.preventDefault(); return; }
+            if (matchesKey(e, 'd')) { toggleTool('door'); e.preventDefault(); return; }
+            if (matchesKey(e, 'o')) { toggleTool('window'); e.preventDefault(); return; }
+            if (matchesKey(e, 'm')) { toggleTool('measure'); e.preventDefault(); return; }
         }
 
         // Обработка сочетаний с Ctrl/Meta
         if (e.ctrlKey || e.metaKey) {
-            switch (e.key.toLowerCase()) {
-                case 'z':
-                    e.preventDefault();
-                    undo();
-                    return;
-                case 'y':
-                    e.preventDefault();
-                    redo();
-                    return;
-                case 'd':
-                    e.preventDefault();
-                    if (state.selectedObject) duplicateObject(state.selectedObject);
-                    return;
-                case 'c':
-                    if (state.selectedObject) {
-                        sessionStorage.setItem('clipboard-layout', JSON.stringify(getModel(state.selectedObject)));
-                        utils.showToast('Скопировано');
-                    }
-                    return;
-                case 'v': {
-                    const raw = sessionStorage.getItem('clipboard-layout');
-                    if (!raw) return;
-                    try {
-                        const m2 = JSON.parse(raw);
-                        m2.x += 12;
-                        m2.y += 12;
-                        const el = createLayoutObject(m2.tpl, m2.x, m2.y);
-                        setModel(el, m2);
-                        selectObject(el);
-                        commit('paste');
-                    } catch (err) {}
-                    return;
+            if (matchesKey(e, 'z')) {
+                e.preventDefault();
+                undo();
+                return;
+            }
+            if (matchesKey(e, 'y')) {
+                e.preventDefault();
+                redo();
+                return;
+            }
+            if (matchesKey(e, 'd')) {
+                e.preventDefault();
+                if (state.selectedObject) duplicateObject(state.selectedObject);
+                return;
+            }
+            if (matchesKey(e, 'c')) {
+                if (state.selectedObject) {
+                    sessionStorage.setItem('clipboard-layout', JSON.stringify(getModel(state.selectedObject)));
+                    utils.showToast('Скопировано');
                 }
+                return;
+            }
+            if (matchesKey(e, 'v')) {
+                const raw = sessionStorage.getItem('clipboard-layout');
+                if (!raw) return;
+                try {
+                    const m2 = JSON.parse(raw);
+                    m2.x += 12;
+                    m2.y += 12;
+                    const el = createLayoutObject(m2.tpl, m2.x, m2.y);
+                    setModel(el, m2);
+                    selectObject(el);
+                    commit('paste');
+                } catch (err) {}
+                return;
             }
         }
 
         // Фокусировка на выбранном объекте по клавише F
         if (!e.ctrlKey && !e.metaKey && !e.altKey) {
-            if (e.key.toLowerCase() === 'f') {
+            if (matchesKey(e, 'f')) {
                 e.preventDefault();
                 focusSelected();
                 return;
@@ -2427,20 +2942,16 @@
         }
 
         // Дополнительные операции с выделенным
-        switch (e.key.toLowerCase()) {
-            case 'r':
-                model.a = (model.a + 90) % 360;
-                setModel(state.selectedObject, model);
-                commit('rotate90');
-                break;
-            case 'f':
-                dom.itemsContainer.appendChild(state.selectedObject);
-                commit('front');
-                break;
-            case 'b':
-                dom.itemsContainer.prepend(state.selectedObject);
-                commit('back');
-                break;
+        if (matchesKey(e, 'r')) {
+            model.a = (model.a + 90) % 360;
+            setModel(state.selectedObject, model);
+            commit('rotate90');
+        } else if (matchesKey(e, 'f')) {
+            dom.itemsContainer.appendChild(state.selectedObject);
+            commit('front');
+        } else if (matchesKey(e, 'b')) {
+            dom.itemsContainer.prepend(state.selectedObject);
+            commit('back');
         }
     }
     function deleteObject(el) { if (!el) return; if (getModel(el).locked) { utils.showToast('Объект заблокирован'); return; } interact(el).unset(); el.remove(); selectObject(null); commit('delete'); }
@@ -2678,6 +3189,24 @@
             });
         }
 
+        if (dom.btnClearHost) {
+            dom.btnClearHost.addEventListener('click', () => {
+                if (!hasLayoutContent()) {
+                    utils.showToast('План уже пуст');
+                    dom.btnClearHost.blur();
+                    return;
+                }
+                try {
+                    clearHost();
+                } catch (err) {
+                    console.error('Не удалось очистить план', err);
+                    utils.showToast('Не удалось очистить план');
+                } finally {
+                    dom.btnClearHost.blur();
+                }
+            });
+        }
+
         // Экспорт сметы в CSV
         if (dom.btnCsv) {
             dom.btnCsv.addEventListener('click', () => {
@@ -2711,6 +3240,9 @@
     }
     
     function init() {
+        buildSymbolsFromSchematic();
+        setRenderMode(state.renderMode, { rerender: false });
+
         // Populate sidebar
         const fragment = document.createDocumentFragment();
         FURNITURE_CATEGORIES.forEach(cat => {
@@ -2728,7 +3260,7 @@
 
         // Setup interact.js
         interact('.draggable-item').draggable({ inertia: true, autoScroll: true, listeners: { start(e) { const g = e.target.cloneNode(true); Object.assign(g.style, { position: 'absolute', opacity: .7, pointerEvents: 'none', zIndex: 1000 }); document.body.appendChild(g); e.interaction.ghost = g; }, move(e) { const g = e.interaction.ghost; if (!g) return; g.style.left = `${e.clientX - e.rect.width / 2}px`; g.style.top = `${e.clientY - e.rect.height / 2}px`; }, end(e) { e.interaction.ghost?.remove(); } } });
-        interact(dom.svg).dropzone({ accept: '.draggable-item', listeners: { drop(e) { const tpl = e.relatedTarget.dataset.template; const viewBox = dom.svg.viewBox.baseVal; const centerX = viewBox.x + viewBox.width / 2; const centerY = viewBox.y + viewBox.height / 2; const obj = createLayoutObject(tpl, centerX, centerY); selectObject(obj); }, dragenter: e => e.target.style.outline = '2px dashed var(--accent)', dragleave: e => e.target.style.outline = 'none', dropdeactivate: e => e.target.style.outline = 'none' } });
+        interact(dom.svg).dropzone({ accept: '.draggable-item', listeners: { drop(e) { const tpl = e.relatedTarget.dataset.template; const viewBox = dom.svg.viewBox.baseVal; const centerX = viewBox.x + viewBox.width / 2; const centerY = viewBox.y + viewBox.height / 2; const obj = createLayoutObject(tpl, centerX, centerY); selectObject(obj); }, dragenter: e => e.target.style.outline = '2px dashed var(--ui-accent)', dragleave: e => e.target.style.outline = 'none', dropdeactivate: e => e.target.style.outline = 'none' } });
         interact(dom.trash).dropzone({ accept: '.layout-object', ondragenter: e => e.target.classList.add('drag-enter'), ondragleave: e => e.target.classList.remove('drag-enter'), ondrop: e => { deleteObject(e.relatedTarget); e.target.classList.remove('drag-enter'); } });
         
         // Bind all event listeners

--- a/index.html
+++ b/index.html
@@ -55,6 +55,8 @@
                     <button id="btnCsv" title="Экспорт сметы CSV" data-icon="i-csv">Смета CSV</button>
                     <!-- Кнопка для загрузки шаблонного проекта -->
                     <button id="btnTemplate" title="Загрузить мастер-проект" data-icon="i-template">Шаблон</button>
+                    <!-- Кнопка для очистки холста -->
+                    <button id="btnClearHost" type="button" title="Очистить план" aria-label="Очистить план" data-icon="i-reset" data-icon-only>Очистить</button>
                 </div>
                 
                 <div id="grid-controls-bar" class="ui-bar">
@@ -76,7 +78,7 @@
                     <label><input type="checkbox" id="snapGuides" checked> Направляющие</label>
                 </div>
 
-                <svg id="svg" viewBox="0 0 1000 1000" preserveAspectRatio="xMidYMid meet" aria-label="План помещения" tabindex="0">
+                <svg id="svg" class="svg-mode--schematic" viewBox="0 0 1000 1000" preserveAspectRatio="xMidYMid meet" aria-label="План помещения" tabindex="0">
                     <defs>
                         <filter id="shadow" x="-50%" y="-50%" width="200%" height="200%">
                             <feDropShadow dx="0" dy="4" stdDeviation="4" flood-color="#000000" flood-opacity="0.1"/>
@@ -84,6 +86,28 @@
                         <pattern id="grid" width="50" height="50" patternUnits="userSpaceOnUse">
                             <path d="M 50 0 L 0 0 0 50" fill="none" stroke="#e9ecef" stroke-width="1" vector-effect="non-scaling-stroke" shape-rendering="crispEdges"/>
                         </pattern>
+                        <style>
+                            .wall-body {
+                                stroke: rgba(15,46,43,0.35);
+                                stroke-linejoin: round;
+                                stroke-linecap: butt;
+                                vector-effect: non-scaling-stroke;
+                                fill: none;
+                            }
+                            .wall-edge {
+                                stroke: #0F2E2B;
+                                stroke-width: 0.6mm;
+                                stroke-linejoin: round;
+                                stroke-linecap: butt;
+                                vector-effect: non-scaling-stroke;
+                                fill: none;
+                            }
+                            .floor-underlay { fill: rgba(243,238,230,0.10); }
+                        </style>
+                        <mask id="wallOpeningsMask" maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse">
+                            <rect x="-10000" y="-10000" width="20000" height="20000" fill="white"/>
+                            <g data-role="wall-mask-openings"></g>
+                        </mask>
                         <marker id="dim-arrow" viewBox="0 0 10 10" refX="1" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
                             <path d="M0 0L10 5L0 10z" fill="#aaa" />
                         </marker>
@@ -180,7 +204,9 @@
                         <rect id="grid-surface" width="100%" height="100%" fill="none" opacity="1"/>
                         <g id="grid-lines" aria-hidden="true"></g>
                     </g>
-                    <g id="underlay-layer"></g>
+                    <g id="underlay-layer">
+                        <rect class="floor-underlay" x="0" y="0" width="100%" height="100%"></rect>
+                    </g>
                     <g id="walls-layer"></g>
                     <g id="openings-layer"></g>
                     <g id="items-layer"></g>
@@ -239,6 +265,11 @@
                     <symbol id="i-export" viewBox="0 0 24 24">
                         <path d="M12 3v10M8 7l4-4 4 4" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
                         <rect x="4" y="13" width="16" height="8" rx="2" stroke="currentColor" stroke-width="2" fill="none"/>
+                    </symbol>
+                    <!-- Очистить -->
+                    <symbol id="i-reset" viewBox="0 0 24 24">
+                        <rect x="4" y="4" width="16" height="16" rx="2" stroke="currentColor" stroke-width="2" fill="none"/>
+                        <path d="M9 9l6 6m0-6l-6 6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
                     </symbol>
                     <!-- Фокус (zoom-to-fit) -->
                     <symbol id="i-zoom-to-fit" viewBox="0 0 24 24">

--- a/style.css
+++ b/style.css
@@ -5,14 +5,21 @@
   --border:#dee2e6;
   --text:#212529;
   --muted:#6c757d;
-  --accent:#0066cc;
   --danger:#dc3545;
-  --stroke:#3b4149;
-  --handle:var(--accent);
+  --ui-accent:#0066cc;
+  --stroke:1.2;
+  --outline:#2b2b2b;
+  --accent:#5d636b;
+  --fill-opacity-light:0.08;
+  --handle:var(--ui-accent);
   --select:rgba(0,102,204,0.85);
   --radius:12px;
   --padding:10px;
 }
+
+.shape{vector-effect:non-scaling-stroke;stroke-width:var(--stroke);stroke-linejoin:round;stroke-linecap:round;}
+.svg-mode--schematic .rich-only{display:none;}
+.svg-mode--rich .schematic-only{display:none;}
 html,body{height:100%;margin:0;background:var(--bg);color:var(--text);font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;overflow:hidden}
 .app{display:flex;height:100%}
 
@@ -22,22 +29,33 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--text);font-famil
 #sidebar h3{font-size:12px;color:var(--muted);font-weight:700;text-transform:uppercase;letter-spacing:.06em;margin:10px 0 6px}
 .draggable-item, .tool-button {display:flex;align-items:center;gap:8px;line-height:1;padding:9px 10px;border:1px solid var(--border);border-radius:8px;margin-bottom:8px;background:#fafafa;cursor:pointer;user-select:none;transition:.2s}
 .draggable-item:hover, .tool-button:hover {background:#e9ecef;box-shadow:0 2px 4px rgba(0,0,0,.08);transform:translateY(-1px)}
-.tool-button.active { background-color: var(--accent); color: white; border-color: var(--accent); }
-#btnExport, #btnAnalysis, #btnCsv, #btnTemplate, #btnFocus, #btn-focus {
+.tool-button.active { background-color: var(--ui-accent); color: white; border-color: var(--ui-accent); }
+#btnExport, #btnAnalysis, #btnCsv, #btnTemplate, #btnFocus, #btn-focus, .ui-bar button[data-icon] {
   display: inline-flex;
   align-items: center;
   gap: 8px;
   line-height: 1;
 }
 
+.ui-bar button[data-icon].icon-only {
+  padding: 6px;
+  gap: 0;
+  justify-content: center;
+}
+
 /* Иконки в кнопках панелей */
-.tool-button .icon, #btnExport .icon, #btnAnalysis .icon, #btnCsv .icon, #btnTemplate .icon, #btnFocus .icon, #btn-focus .icon {
+.tool-button .icon, .ui-bar button[data-icon] .icon, #btnFocus .icon, #btn-focus .icon {
   width: 18px;
   height: 18px;
   display: inline-flex;
 }
 
-.tool-button .icon svg, #btnExport .icon svg, #btnAnalysis .icon svg, #btnCsv .icon svg, #btnTemplate .icon svg, #btnFocus .icon svg, #btn-focus .icon svg {
+.ui-bar button[data-icon].icon-only .icon {
+  width: 20px;
+  height: 20px;
+}
+
+.tool-button .icon svg, .ui-bar button[data-icon] .icon svg, #btnFocus .icon svg, #btn-focus .icon svg {
   width: 18px;
   height: 18px;
   fill: currentColor;
@@ -45,11 +63,16 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--text);font-famil
   opacity: 0.92;
 }
 
+.ui-bar button[data-icon].icon-only .icon svg {
+  width: 20px;
+  height: 20px;
+}
+
 .tool-button.active .icon svg {
   opacity: 1;
 }
 
-.tool-button .label, #btnExport .label, #btnAnalysis .label, #btnCsv .label, #btnTemplate .label, #btnFocus .label, #btn-focus .label {
+.tool-button .label, .ui-bar button[data-icon] .label, #btnFocus .label, #btn-focus .label {
   white-space: nowrap;
 }
 #trash{margin-top:auto;padding:14px;border:2px dashed var(--border);border-radius:8px;text-align:center;color:var(--muted);transition:.3s}
@@ -71,41 +94,32 @@ html,body{height:100%;margin:0;background:var(--bg);color:var(--text);font-famil
 }
 svg{width:100%;height:100%}
 svg.tool-active { cursor: crosshair; }
-.wall,.inner-wall,.win,.col,.door-arc,.dim-line, #walls-layer path {vector-effect:non-scaling-stroke}
-#walls-layer .wall path {
-  fill: none;
+.wall,.inner-wall,.win,.col,.door-arc,.dim-line {vector-effect:non-scaling-stroke}
+#walls-layer .wall {
   cursor: pointer;
-  stroke-linejoin: round;
-  stroke-linecap: round;
+}
+#walls-layer .wall .wall-body,
+#walls-layer .wall .wall-edge {
+  fill: none;
   transition: stroke .2s ease, stroke-width .2s ease, stroke-dasharray .2s ease;
 }
-#walls-layer .wall[data-type="structural"] path {
-  stroke: #343a40;
-  stroke-width: 16;
-}
-#walls-layer .wall[data-type="partition"] path {
-  stroke: #868e96;
-  stroke-width: 10;
-  stroke-dasharray: 28 12;
+#walls-layer .wall .wall-body {
   stroke-linecap: butt;
+  stroke-linejoin: round;
 }
-#walls-layer .wall[data-type="glass"] path {
-  stroke: rgba(77,171,247,.9);
-  stroke-width: 8;
-  stroke-dasharray: 12 8;
+#walls-layer .wall .wall-edge {
   stroke-linecap: butt;
+  stroke-linejoin: round;
+  pointer-events: stroke;
 }
-#walls-layer .wall[data-type="half"] path {
-  stroke: #adb5bd;
-  stroke-width: 8;
-  stroke-dasharray: 6 8;
-  stroke-linecap: butt;
-}
-#walls-layer .wall.selected path {
+#walls-layer .wall.selected .wall-edge {
   filter: drop-shadow(0 0 6px rgba(0,102,204,.6));
 }
+#walls-layer .wall.selected .wall-body {
+  filter: drop-shadow(0 0 4px rgba(0,102,204,.35));
+}
 .wall-component { cursor: pointer; }
-.wall-component.selected > * { stroke: var(--accent) !important; stroke-width: 3; vector-effect: non-scaling-stroke; }
+.wall-component.selected > * { stroke: var(--ui-accent) !important; stroke-width: 3; vector-effect: non-scaling-stroke; }
 .floor{fill:#fdfdfd;}
 #grid-layer{pointer-events:none}
 
@@ -183,8 +197,9 @@ svg.tool-active { cursor: crosshair; }
 }
 #items-layer .layout-object .core .shape {
   paint-order:stroke fill;
-  stroke-width:1.2;
-  stroke:rgba(33,37,41,.18);
+  stroke-width:var(--stroke);
+  stroke:var(--outline);
+  stroke-opacity:0.18;
 }
 .layout-object.selected .selection-box{display:block}
 .selection-box{
@@ -299,18 +314,18 @@ svg.tool-active { cursor: crosshair; }
   color:var(--text);
 }
 .wall-type-option svg{width:48px;height:18px;overflow:visible;}
-.wall-type-option line{stroke-linecap:round;stroke-linejoin:round;}
-.wall-type-option[data-type="structural"] line{stroke:#343a40;stroke-width:12;}
-.wall-type-option[data-type="partition"] line{stroke:#868e96;stroke-width:9;stroke-dasharray:22 10;stroke-linecap:butt;}
-.wall-type-option[data-type="glass"] line{stroke:rgba(77,171,247,.9);stroke-width:7;stroke-dasharray:10 6;stroke-linecap:butt;}
-.wall-type-option[data-type="half"] line{stroke:#adb5bd;stroke-width:7;stroke-dasharray:5 7;stroke-linecap:butt;}
+.wall-type-option line{stroke-linecap:butt;stroke-linejoin:round;}
+.wall-type-option[data-type="structural"] line{stroke:#0F2E2B;stroke-width:12;stroke-opacity:.85;}
+.wall-type-option[data-type="partition"] line{stroke:#0F2E2B;stroke-width:9;stroke-dasharray:18 8;stroke-opacity:.7;}
+.wall-type-option[data-type="glass"] line{stroke:#2F7EBB;stroke-width:7;stroke-dasharray:12 6;}
+.wall-type-option[data-type="half"] line{stroke:#0F2E2B;stroke-width:7;stroke-dasharray:8 6;stroke-opacity:.55;}
 .wall-type-option.active{
-  border-color:var(--accent);
+  border-color:var(--ui-accent);
   box-shadow:0 0 0 2px rgba(0,102,204,.2);
   background:rgba(0,102,204,.06);
-  color:var(--accent);
+  color:var(--ui-accent);
 }
-.wall-type-option:focus-visible{outline:2px solid var(--accent);}
+.wall-type-option:focus-visible{outline:2px solid var(--ui-accent);}
 
 .wall-length-label{
   font-size:18px;
@@ -344,9 +359,9 @@ svg.tool-active { cursor: crosshair; }
 .visually-hidden{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 
 .wall-handles{pointer-events:none}
-.wall-handles circle{fill:var(--accent);stroke:#fff;stroke-width:2;pointer-events:all;cursor:pointer}
+.wall-handles circle{fill:var(--ui-accent);stroke:#fff;stroke-width:2;pointer-events:all;cursor:pointer}
 .wall-handles circle.active{fill:var(--danger)}
-.wall-segment-insert{fill:#fff;stroke:var(--accent);stroke-dasharray:2 2;pointer-events:all;cursor:crosshair;opacity:.7}
+.wall-segment-insert{fill:#fff;stroke:var(--ui-accent);stroke-dasharray:2 2;pointer-events:all;cursor:crosshair;opacity:.7}
 #walls-layer .wall.selected .wall-handles,#walls-layer .wall.selected .wall-segment-insert{display:block}
 #walls-layer .wall .wall-handles,#walls-layer .wall .wall-segment-insert{display:none}
 .status-ok{color:#2b8a3e;font-weight:600}
@@ -358,7 +373,7 @@ svg.tool-active { cursor: crosshair; }
 #layers-list{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:4px}
 #layers-list li{display:flex;align-items:center;gap:8px;padding:6px;border-radius:6px;cursor:pointer;transition:.15s;font-size:13px}
 #layers-list li:hover{background:#f1f3f5}
-#layers-list li.selected{background:var(--accent);color:#fff}
+#layers-list li.selected{background:var(--ui-accent);color:#fff}
 #layers-list .layer-name{flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 #layers-list .layer-vis,#layers-list .layer-lock{border:none;background:none;cursor:pointer;padding:2px 4px;opacity:.6}
 #layers-list li.selected .layer-vis,#layers-list li.selected .layer-lock{opacity:1}

--- a/templates.js
+++ b/templates.js
@@ -140,17 +140,25 @@ const FURNITURE_CATEGORIES = [
 const ITEM_TEMPLATES = {
     'zone': { label: 'Зона', svg: () => `<g class="core"><rect x="-100" y="-75" class="shape" width="200" height="150" rx="10" fill="rgba(13,110,253,0.1)" stroke="rgba(13,110,253,0.3)"/></g>` },
     /* === КОФЕЙНЯ === */
-    'cafe-table-round-60': { label: 'Стол круглый Ø60', svg: () => `<g class="core">
-        <circle class="shape" r="30" fill="url(#wood-oak)" stroke="var(--stroke)"/>
+    'cafe-table-round-60': {
+        label: 'Стол круглый Ø60',
+        svg: () => `<g class="core">
+        <circle class="shape" r="30" fill="url(#wood-oak)" stroke="var(--outline)"/>
         <circle r="26" fill="#ffffff" fill-opacity="0.08"/>
         <g stroke="url(#metal-steel)" stroke-width="4" stroke-linecap="round">
             <line x1="0" y1="30" x2="0" y2="42"/>
             <line x1="-10" y1="42" x2="10" y2="42"/>
         </g>
-    </g>` },
+    </g>`,
+        schematicSvg: () => `
+  <g class="core schematic-only" data-id="cafe-table-round-60">
+    <circle r="30" fill="none" stroke="var(--outline)" class="shape"/>
+    <line x1="0" y1="30" x2="0" y2="44" stroke="var(--outline)" class="shape" stroke-width="1"/>
+  </g>`
+    },
     'cafe-table-square-70': { label: 'Стол квадрат 70×70', svg: () => `<g class="core">
         <rect class="shape" x="-35" y="-35" width="70" height="70" rx="8"
-            fill="url(#wood-oak)" stroke="var(--stroke)"/>
+            fill="url(#wood-oak)" stroke="var(--outline)"/>
         <rect x="-30" y="-30" width="60" height="60" rx="6"
             fill="#ffffff" fill-opacity="0.08"/>
         <g stroke="url(#metal-steel)" stroke-width="4" stroke-linecap="round">
@@ -158,7 +166,7 @@ const ITEM_TEMPLATES = {
         </g>
     </g>` },
     'cafe-hightop-round-70': { label: 'Хай-топ Ø70', svg: () => `<g class="core">
-        <circle class="shape" r="35" fill="url(#wood-espresso)" stroke="var(--stroke)"/>
+        <circle class="shape" r="35" fill="url(#wood-espresso)" stroke="var(--outline)"/>
         <circle r="30" fill="#000" fill-opacity="0.08"/>
         <g stroke="url(#metal-steel)" stroke-width="4" stroke-linecap="round">
             <line x1="0" y1="35" x2="0" y2="48"/><line x1="-12" y1="48" x2="12" y2="48"/>
@@ -166,7 +174,7 @@ const ITEM_TEMPLATES = {
     </g>` },
     'cafe-communal-240': { label: 'Коммунальный 240×90', svg: () => `<g class="core">
         <rect class="shape" x="-120" y="-45" width="240" height="90" rx="10"
-            fill="url(#wood-oak)" stroke="var(--stroke)"/>
+            fill="url(#wood-oak)" stroke="var(--outline)"/>
         <rect x="-112" y="-37" width="224" height="74" rx="8"
             fill="#ffffff" fill-opacity="0.06"/>
         <g stroke="url(#metal-steel)" stroke-width="4" stroke-linecap="round">
@@ -200,7 +208,7 @@ const ITEM_TEMPLATES = {
         <rect x="-45" y="-52" width="90" height="20" rx="10"
             fill="url(#upholstery-slate)" stroke="#3b4149"/>
         <rect x="-18" y="-10" width="36" height="20" rx="6"
-            fill="url(#wood-oak)" stroke="var(--stroke)"/>
+            fill="url(#wood-oak)" stroke="var(--outline)"/>
     </g>` },
     'booth-4': { label: 'Кабинка на 4', svg: () => `<g class="core">
         <rect x="-70" y="-40" width="140" height="80" rx="12"
@@ -208,11 +216,11 @@ const ITEM_TEMPLATES = {
         <rect x="-70" y="-58" width="140" height="20" rx="10"
             fill="url(#upholstery-slate)" stroke="#3b4149"/>
         <rect x="-24" y="-12" width="48" height="24" rx="6"
-            fill="url(#wood-oak)" stroke="var(--stroke)"/>
+            fill="url(#wood-oak)" stroke="var(--outline)"/>
     </g>` },
     'bar-counter-straight-180': { label: 'Барная стойка 180', svg: () => `<g class="core">
         <rect class="shape" x="-90" y="-36" width="180" height="72" rx="8"
-            fill="url(#counter-marble)" stroke="var(--stroke)"/>
+            fill="url(#counter-marble)" stroke="var(--outline)"/>
         <rect x="-90" y="-8" width="180" height="16" rx="6"
             fill="rgba(0,0,0,0.08)"/>
         <g stroke="url(#metal-steel)" stroke-width="4" stroke-linecap="round">
@@ -222,7 +230,7 @@ const ITEM_TEMPLATES = {
     </g>` },
     'bar-counter-straight-240': { label: 'Барная стойка 240', svg: () => `<g class="core">
         <rect class="shape" x="-120" y="-36" width="240" height="72" rx="8"
-            fill="url(#counter-marble)" stroke="var(--stroke)"/>
+            fill="url(#counter-marble)" stroke="var(--outline)"/>
         <rect x="-120" y="-8" width="240" height="16" rx="6"
             fill="rgba(0,0,0,0.08)"/>
         <g stroke="url(#metal-steel)" stroke-width="4" stroke-linecap="round">
@@ -233,13 +241,13 @@ const ITEM_TEMPLATES = {
     </g>` },
     'bar-counter-l-180x180': { label: 'Барная стойка Г 180×180', svg: () => `<g class="core">
         <path class="shape" d="M-90 -36 H90 V36 H-36 V90 H-90 Z"
-            fill="url(#counter-marble)" stroke="var(--stroke)"/>
+            fill="url(#counter-marble)" stroke="var(--outline)"/>
         <rect x="-90" y="-8" width="180" height="16" rx="6" fill="rgba(0,0,0,0.08)"/>
         <rect x="-8" y="-36" width="16" height="126" rx="6" fill="rgba(0,0,0,0.08)"/>
     </g>` },
     'bar-counter-island-180x90': { label: 'Бар-остров 180×90', svg: () => `<g class="core">
         <rect class="shape" x="-90" y="-45" width="180" height="90" rx="10"
-            fill="url(#counter-marble)" stroke="var(--stroke)"/>
+            fill="url(#counter-marble)" stroke="var(--outline)"/>
         <rect x="-90" y="-10" width="180" height="20" rx="8" fill="rgba(0,0,0,0.08)"/>
     </g>` },
     'bar-back-shelf-180': { label: 'Задняя барная полка 180', svg: () => `<g class="core">
@@ -252,9 +260,9 @@ const ITEM_TEMPLATES = {
     </g>` },
     'espresso-2g': { label: 'Эспрессо-машина 2 группы', svg: () => `<g class="core">
         <rect class="shape" x="-46" y="-22" width="92" height="44" rx="8"
-            fill="url(#metal-chrome)" stroke="var(--stroke)"/>
+            fill="url(#metal-chrome)" stroke="var(--outline)"/>
         <rect x="-40" y="-30" width="80" height="10" rx="6"
-            fill="url(#metal-steel)" stroke="var(--stroke)"/>
+            fill="url(#metal-steel)" stroke="var(--outline)"/>
         <g fill="url(#metal-steel)">
             <rect x="-28" y="-6" width="16" height="12" rx="2"/>
             <rect x="12"  y="-6" width="16" height="12" rx="2"/>
@@ -263,9 +271,9 @@ const ITEM_TEMPLATES = {
     </g>` },
     'espresso-3g': { label: 'Эспрессо-машина 3 группы', svg: () => `<g class="core">
         <rect class="shape" x="-66" y="-22" width="132" height="44" rx="8"
-            fill="url(#metal-chrome)" stroke="var(--stroke)"/>
+            fill="url(#metal-chrome)" stroke="var(--outline)"/>
         <rect x="-60" y="-30" width="120" height="10" rx="6"
-            fill="url(#metal-steel)" stroke="var(--stroke)"/>
+            fill="url(#metal-steel)" stroke="var(--outline)"/>
         <g fill="url(#metal-steel)">
             <rect x="-40" y="-6" width="16" height="12" rx="2"/>
             <rect x="-8"  y="-6" width="16" height="12" rx="2"/>
@@ -275,84 +283,84 @@ const ITEM_TEMPLATES = {
     </g>` },
     'grinder-80mm': { label: 'Кофемолка 80 мм', svg: () => `<g class="core">
         <rect class="shape" x="-12" y="-18" width="24" height="36" rx="4"
-            fill="url(#metal-steel)" stroke="var(--stroke)"/>
+            fill="url(#metal-steel)" stroke="var(--outline)"/>
         <polygon points="-10,-20 10,-20 6,-34 -6,-34"
-                fill="url(#glass-soft)" stroke="var(--stroke)"/>
+                fill="url(#glass-soft)" stroke="var(--outline)"/>
     </g>` },
     'batch-brewer-2': { label: 'Бэтч-брю (2 станции)', svg: () => `<g class="core">
         <rect class="shape" x="-40" y="-22" width="80" height="44" rx="6"
-            fill="url(#metal-steel)" stroke="var(--stroke)"/>
-        <g fill="url(#glass-soft)" stroke="var(--stroke)">
+            fill="url(#metal-steel)" stroke="var(--outline)"/>
+        <g fill="url(#glass-soft)" stroke="var(--outline)">
             <rect x="-26" y="-10" width="18" height="18" rx="3"/>
             <rect x="8"   y="-10" width="18" height="18" rx="3"/>
         </g>
     </g>` },
     'pour-over-3': { label: 'Пуровер-станция ×3', svg: () => `<g class="core">
         <rect class="shape" x="-60" y="-18" width="120" height="36" rx="6"
-            fill="url(#wood-oak)" stroke="var(--stroke)"/>
-        <g fill="url(#glass-soft)" stroke="var(--stroke)">
+            fill="url(#wood-oak)" stroke="var(--outline)"/>
+        <g fill="url(#glass-soft)" stroke="var(--outline)">
             <circle cx="-40" r="10"/><circle cx="0" r="10"/><circle cx="40" r="10"/>
         </g>
     </g>` },
     'kettle-electric': { label: 'Электрочайник', svg: () => `<g class="core">
         <ellipse class="shape" cx="0" cy="0" rx="16" ry="12"
-            fill="url(#metal-steel)" stroke="var(--stroke)"/>
+            fill="url(#metal-steel)" stroke="var(--outline)"/>
         <rect x="-10" y="-8" width="20" height="16" rx="4"
-            fill="url(#metal-chrome)" stroke="var(--stroke)"/>
+            fill="url(#metal-chrome)" stroke="var(--outline)"/>
     </g>` },
     'water-filter': { label: 'Фильтр воды под мойкой', svg: () => `<g class="core">
         <rect class="shape" x="-20" y="-14" width="40" height="28" rx="6"
-            fill="url(#metal-steel)" stroke="var(--stroke)"/>
-        <g fill="url(#metal-chrome)" stroke="var(--stroke)">
+            fill="url(#metal-steel)" stroke="var(--outline)"/>
+        <g fill="url(#metal-chrome)" stroke="var(--outline)">
             <rect x="-14" y="-8" width="10" height="16" rx="3"/>
             <rect x="4"   y="-8" width="10" height="16" rx="3"/>
         </g>
     </g>` },
     'ice-machine-60': { label: 'Льдогенератор 60', svg: () => `<g class="core">
         <rect class="shape" x="-30" y="-30" width="60" height="60" rx="6"
-            fill="url(#metal-steel)" stroke="var(--stroke)"/>
+            fill="url(#metal-steel)" stroke="var(--outline)"/>
         <rect x="-26" y="-10" width="52" height="14" rx="4"
             fill="#111" fill-opacity="0.35"/>
     </g>` },
     'undercounter-fridge-90': { label: 'Холод под столеш. 90', svg: () => `<g class="core">
         <rect class="shape" x="-45" y="-30" width="90" height="60" rx="6"
-            fill="url(#metal-steel)" stroke="var(--stroke)"/>
+            fill="url(#metal-steel)" stroke="var(--outline)"/>
         <rect x="-41" y="-26" width="82" height="52" rx="4"
-            fill="#dfe6ee" stroke="var(--stroke)"/>
-        <line x1="0" y1="-26" x2="0" y2="26" stroke="var(--stroke)"/>
+            fill="#dfe6ee" stroke="var(--outline)"/>
+        <line x1="0" y1="-26" x2="0" y2="26" stroke="var(--outline)"/>
     </g>` },
     'upright-fridge-60': { label: 'Холодильник 60', svg: () => `<g class="core">
         <rect class="shape" x="-30" y="-36" width="60" height="72" rx="6"
-            fill="url(#metal-steel)" stroke="var(--stroke)"/>
+            fill="url(#metal-steel)" stroke="var(--outline)"/>
         <rect x="-26" y="-32" width="52" height="64" rx="4"
-            fill="#dfe6ee" stroke="var(--stroke)"/>
+            fill="#dfe6ee" stroke="var(--outline)"/>
     </g>` },
     'milk-fridge-60': { label: 'Молочный холодильник 60', svg: () => `<g class="core">
         <rect class="shape" x="-30" y="-28" width="60" height="56" rx="6"
-            fill="url(#metal-steel)" stroke="var(--stroke)"/>
+            fill="url(#metal-steel)" stroke="var(--outline)"/>
         <rect x="-24" y="-22" width="48" height="44" rx="4"
-            fill="#dfe6ee" stroke="var(--stroke)"/>
+            fill="#dfe6ee" stroke="var(--outline)"/>
         <rect x="-20" y="-18" width="40" height="10" rx="3"
-            fill="#fff" fill-opacity="0.7" stroke="var(--stroke)"/>
+            fill="#fff" fill-opacity="0.7" stroke="var(--outline)"/>
     </g>` },
     'freezer-60': { label: 'Морозильник 60', svg: () => `<g class="core">
         <rect class="shape" x="-30" y="-30" width="60" height="60" rx="6"
-            fill="url(#metal-steel)" stroke="var(--stroke)"/>
+            fill="url(#metal-steel)" stroke="var(--outline)"/>
         <rect x="-25" y="-10" width="50" height="20" rx="3"
-            fill="#eaf6ff" stroke="var(--stroke)"/>
+            fill="#eaf6ff" stroke="var(--outline)"/>
     </g>` },
     'pastry-case-120': { label: 'Витрина кондит. прямая 120', svg: () => `<g class="core">
         <rect class="shape" x="-60" y="-30" width="120" height="60" rx="8"
             fill="url(#wood-espresso)" stroke="#2c180d"/>
         <rect x="-58" y="-38" width="116" height="16" rx="6"
-            fill="url(#glass-soft)" stroke="var(--stroke)"/>
+            fill="url(#glass-soft)" stroke="var(--outline)"/>
     </g>` },
     'pastry-case-120-curved': { label: 'Витрина кондит. радиус 120', svg: () => `<g class="core">
         <rect class="shape" x="-60" y="-30" width="120" height="60" rx="8"
             fill="url(#wood-espresso)" stroke="#2c180d"/>
-        <path d="M-58 -30 Q0 -50 58 -30" fill="url(#glass-soft)" stroke="var(--stroke)"/>
+        <path d="M-58 -30 Q0 -50 58 -30" fill="url(#glass-soft)" stroke="var(--outline)"/>
         <rect x="-58" y="-38" width="116" height="8" rx="4"
-            fill="url(#glass-soft)" stroke="var(--stroke)"/>
+            fill="url(#glass-soft)" stroke="var(--outline)"/>
     </g>` },
     'pos-terminal': { label: 'POS-терминал', svg: () => `<g class="core">
         <rect class="shape" x="-18" y="-12" width="36" height="24" rx="4"
@@ -363,12 +371,12 @@ const ITEM_TEMPLATES = {
     </g>` },
     'cash-drawer': { label: 'Денежный ящик', svg: () => `<g class="core">
         <rect class="shape" x="-24" y="-14" width="48" height="28" rx="4"
-            fill="url(#metal-steel)" stroke="var(--stroke)"/>
+            fill="url(#metal-steel)" stroke="var(--outline)"/>
         <circle cx="0" cy="0" r="2.5" fill="#333"/>
     </g>` },
     'condiment-120': { label: 'Станция приправ 120', svg: () => `<g class="core">
         <rect class="shape" x="-60" y="-22" width="120" height="44" rx="6"
-            fill="url(#wood-oak)" stroke="var(--stroke)"/>
+            fill="url(#wood-oak)" stroke="var(--outline)"/>
         <g fill="#fff" fill-opacity="0.75" stroke="#ccc">
             <rect x="-48" y="-12" width="24" height="18" rx="3"/>
             <rect x="-12" y="-12" width="24" height="18" rx="3"/>
@@ -395,13 +403,13 @@ const ITEM_TEMPLATES = {
     </g>` },
     'hand-sink': { label: 'Раковина для рук', svg: () => `<g class="core">
         <rect class="shape" x="-20" y="-16" width="40" height="32" rx="6"
-            fill="#e9f1fb" stroke="var(--stroke)"/>
+            fill="#e9f1fb" stroke="var(--outline)"/>
         <circle r="5" fill="#c8d7ea"/>
     </g>` },
     'triple-sink': { label: 'Мойка 3-секц.', svg: () => `<g class="core">
         <rect class="shape" x="-90" y="-26" width="180" height="52" rx="8"
-            fill="#e9f1fb" stroke="var(--stroke)"/>
-        <g fill="#c8d7ea" stroke="var(--stroke)">
+            fill="#e9f1fb" stroke="var(--outline)"/>
+        <g fill="#c8d7ea" stroke="var(--outline)">
             <rect x="-70" y="-14" width="40" height="28" rx="5"/>
             <rect x="-20" y="-14" width="40" height="28" rx="5"/>
             <rect x="30"  y="-14" width="40" height="28" rx="5"/>
@@ -409,13 +417,13 @@ const ITEM_TEMPLATES = {
     </g>` },
     'dishwasher-pro': { label: 'Посудомойка подстол.', svg: () => `<g class="core">
         <rect class="shape" x="-28" y="-24" width="56" height="48" rx="6"
-            fill="url(#metal-steel)" stroke="var(--stroke)"/>
+            fill="url(#metal-steel)" stroke="var(--outline)"/>
         <rect x="-24" y="-6" width="48" height="12" rx="3"
-            fill="#eaf6ff" stroke="var(--stroke)"/>
+            fill="#eaf6ff" stroke="var(--outline)"/>
     </g>` },
     'drying-rack-120': { label: 'Сушка посуды 120', svg: () => `<g class="core">
         <rect class="shape" x="-60" y="-10" width="120" height="20" rx="4"
-            fill="url(#metal-steel)" stroke="var(--stroke)"/>
+            fill="url(#metal-steel)" stroke="var(--outline)"/>
         <g stroke="#aab7c6">
             <line x1="-50" y1="-8" x2="-50" y2="8"/><line x1="-30" y1="-8" x2="-30" y2="8"/>
             <line x1="-10" y1="-8" x2="-10" y2="8"/><line x1="10" y1="-8" x2="10" y2="8"/>
@@ -423,7 +431,7 @@ const ITEM_TEMPLATES = {
         </g>
     </g>` },
     'queue-post': { label: 'Стойка очереди', svg: () => `<g class="core">
-        <circle class="shape" r="10" fill="url(#metal-steel)" stroke="var(--stroke)"/>
+        <circle class="shape" r="10" fill="url(#metal-steel)" stroke="var(--outline)"/>
         <circle r="14" fill="#000" fill-opacity="0.06"/>
     </g>` },
     'menu-board-120': { label: 'Меню-борд 120', svg: () => `<g class="core">
@@ -434,7 +442,7 @@ const ITEM_TEMPLATES = {
     </g>` },
     'planter-long-120': { label: 'Кашпо длинное 120', svg: () => `<g class="core">
         <rect class="shape" x="-60" y="-14" width="120" height="28" rx="6"
-            fill="url(#wood-oak)" stroke="var(--stroke)"/>
+            fill="url(#wood-oak)" stroke="var(--outline)"/>
         <rect x="-56" y="-18" width="112" height="10" rx="5"
             fill="url(#foliage-rich)" stroke="#2c6b3f"/>
     </g>` },
@@ -442,7 +450,9 @@ const ITEM_TEMPLATES = {
         <rect class="shape" x="-60" y="-5" width="120" height="10" rx="3"
             fill="#cbd3dd" stroke="#9aa4b0"/>
     </g>` },
-    'chair': { label: 'Стул', svg: () => `<g class="core">
+    'chair': {
+        label: 'Стул',
+        svg: () => `<g class="core">
         <g fill="none" stroke="url(#metal-steel)" stroke-width="3.4" stroke-linecap="round">
             <path d="M-15 10 L-12 32"/>
             <path d="M15 10 L12 32"/>
@@ -453,7 +463,13 @@ const ITEM_TEMPLATES = {
         <rect class="shape" x="-20" y="-2" width="40" height="24" rx="7" fill="url(#upholstery-amber)" stroke="#714624"/>
         <rect x="-18" y="-20" width="36" height="10" rx="5" fill="url(#wood-espresso)" stroke="#2c180d"/>
         <rect x="-14" y="2" width="28" height="6" rx="3" fill="#fff4de" fill-opacity="0.25"/>
-    </g>` },
+    </g>`,
+        schematicSvg: () => `
+  <g class="core schematic-only" data-id="chair">
+    <rect x="-10" y="-10" width="20" height="20" rx="3" fill="none" stroke="var(--outline)" class="shape"/>
+    <line x1="0" y1="10" x2="0" y2="20" stroke="var(--outline)" class="shape" stroke-width="0.9"/>
+  </g>`
+    },
     'armchair': { label: 'Кресло', svg: () => `<g class="core">
         <rect x="-44" y="-32" width="88" height="64" rx="20" fill="url(#upholstery-slate)" stroke="#2f363f"/>
         <rect x="-42" y="-20" width="18" height="48" rx="8" fill="url(#leather-caramel)" stroke="#4d2d17"/>


### PR DESCRIPTION
## Summary
- prepend runtime translate/scale transforms ahead of cached template transforms so `.core` graphics keep their static offsets while resizing
- derive wall body stroke widths from 1:50 sheet millimetre values and reuse the same thickness for masks and component openings
- reuse the wall thickness helper when rendering door/window inserts so their geometry matches the masked wall body

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd8a0290348333bd1970179743d2a1