### PR TITLE
Add schematic mode toggle and document rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,31 @@ The application currently relies on interactive workflows, so the following manu
 5. **Legacy import compatibility**
    - Import a pre-update JSON project (walls stored as SVG paths) and confirm walls convert to editable segments.
    - Import a project with old door/window markup and check that openings snap to the nearest wall segment and follow the wall when moved.
+
+## Плановый режим и откат изменений
+
+- Все шаблоны из `templates.js` дополнены функциями `schematicSvg()` и автоматически получают плановый вариант из `templates.schematic.patch.js`.
+- В `app.js` реализован безопасный `applyTransformFromDataset()` и переключатель между `schematic`/`rich` режимами (кнопка «Режим: План/Детально» в нижней панели).
+- Стиль `style.css` содержит набор переменных и классов (`shape`, `shape-fill`, `furn-center`, `schematic-only`, `rich-only`) для единообразного рендера.
+
+### Как проверить плановый вид
+1. Откройте `index.html` в браузере.
+2. Используйте кнопку «Режим: План/Детально» или вызовите `setRenderMode('schematic')`/`setRenderMode('rich')` в консоли DevTools.
+3. В режиме схемы убедитесь, что мебель упрощена, центрирована (`core.getBBox()` ≈ центр в (0,0)) и линии имеют единый стиль.
+4. Переключитесь обратно в детализированный режим и проверьте, что исходная графика не искажена.
+
+### Быстрый откат к исходным файлам
+
+```bash
+cp templates.js.bak templates.js
+cp app.js.bak app.js
+```
+
+При необходимости можно снова применить патчи:
+
+```bash
+cp app.patched.js app.js
+node templates.schematic.patch.js
+```
+
+После отката перезапустите страницу и очистите `localStorage`, чтобы убедиться, что все элементы и стены отображаются корректно.

--- a/app.js
+++ b/app.js
@@ -54,6 +54,7 @@
         btnImport: document.getElementById('btnImport'),
         fileImport: document.getElementById('fileImport'),
         btnShare: document.getElementById('btnShare'),
+        renderModeToggle: document.getElementById('toggle-render-mode'),
         btnAnalysis: document.getElementById('btnAnalysis'),
         btnCsv: document.getElementById('btnCsv'),
         btnTemplate: document.getElementById('btnTemplate'),
@@ -1398,11 +1399,26 @@
         dom.svg.classList.add(mode === 'rich' ? 'svg-mode--rich' : 'svg-mode--schematic');
     }
 
+    function updateRenderModeToggle(mode = state.renderMode) {
+        if (!dom.renderModeToggle) return;
+        const normalized = mode === 'rich' ? 'rich' : 'schematic';
+        const text = normalized === 'rich' ? 'Режим: Детально' : 'Режим: План';
+        const labelNode = dom.renderModeToggle.querySelector('.label');
+        if (labelNode) {
+            labelNode.textContent = text;
+        } else {
+            dom.renderModeToggle.textContent = text;
+        }
+        dom.renderModeToggle.setAttribute('aria-pressed', normalized === 'rich' ? 'true' : 'false');
+        dom.renderModeToggle.dataset.mode = normalized;
+    }
+
     function setRenderMode(mode, { rerender = true } = {}) {
         const next = mode === 'rich' ? 'rich' : 'schematic';
         const prev = state.renderMode;
         state.renderMode = next;
         updateSvgModeClass(next);
+        updateRenderModeToggle(next);
         if (rerender && prev !== next) {
             rerenderAllLayoutObjects();
             commit('render_mode_change');
@@ -3229,6 +3245,10 @@
         dom.btnExport.addEventListener('click', () => { const a = document.createElement('a'); a.href = URL.createObjectURL(new Blob([JSON.stringify(snapshot(), null, 2)], { type: 'application/json' })); a.download = 'layout.json'; a.click(); URL.revokeObjectURL(a.href); });
         dom.btnImport.addEventListener('click', () => dom.fileImport.click());
         dom.fileImport.addEventListener('change', e => { const f = e.target.files?.[0]; if (!f) return; const r = new FileReader(); r.onload = () => { try { const data = JSON.parse(r.result); restore(data); commit('import'); utils.showToast('План импортирован'); } catch (err) { utils.showToast('Ошибка импорта'); } }; r.readAsText(f); });
+        dom.renderModeToggle?.addEventListener('click', () => {
+            const next = state.renderMode === 'schematic' ? 'rich' : 'schematic';
+            setRenderMode(next);
+        });
 
         // Запуск анализа планировки по нажатию кнопки "Анализ"
         if (dom.btnAnalysis) {

--- a/index.html
+++ b/index.html
@@ -49,6 +49,7 @@
                     <input id="fileImport" type="file" accept="application/json" hidden>
                     <button id="btnImport" title="Импорт JSON">Импорт</button>
                     <button id="btnShare" title="Скопировать ссылку">Поделиться</button>
+                    <button id="toggle-render-mode" type="button" data-icon="i-render-mode" aria-pressed="false">Режим: План</button>
                     <!-- Кнопка для запуска анализа планировки -->
                     <button id="btnAnalysis" title="Анализ планировки" data-icon="i-analyze">Анализ</button>
                     <!-- Кнопка для экспорта сметы и данных в CSV -->
@@ -265,6 +266,12 @@
                     <symbol id="i-export" viewBox="0 0 24 24">
                         <path d="M12 3v10M8 7l4-4 4 4" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round"/>
                         <rect x="4" y="13" width="16" height="8" rx="2" stroke="currentColor" stroke-width="2" fill="none"/>
+                    </symbol>
+                    <symbol id="i-render-mode" viewBox="0 0 24 24">
+                        <rect x="3" y="4" width="8" height="16" rx="2" stroke="currentColor" stroke-width="2" fill="none"/>
+                        <rect x="13" y="6" width="8" height="12" rx="2" stroke="currentColor" stroke-width="2" fill="none"/>
+                        <line x1="7" y1="10" x2="9" y2="10" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                        <line x1="17" y1="12" x2="19" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
                     </symbol>
                     <!-- Очистить -->
                     <symbol id="i-reset" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary
- add a render-mode toggle button with a dedicated icon so the schematic view can be switched without DevTools
- sync the new toggle with the renderer so schematic/rich swaps update markup and button state
- extend the README with schematic-view verification and rollback instructions

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d050be64448333a530762a97c68b0a