### PR TITLE
Fix door swing, underlay scaling, and decorative assets

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,6 +37,7 @@
         gridPattern: document.getElementById('grid'),
         gridRect: document.getElementById('grid-surface'),
         gridLinesGroup: document.getElementById('grid-lines'),
+        floorUnderlay: document.getElementById('floor-underlay'),
         layersPanel: document.getElementById('layers-panel'),
         layersList: document.getElementById('layers-list'),
         main: document.getElementById('main'),
@@ -1196,7 +1197,6 @@
         if (!(widthUnits > 0)) return '';
         const transforms = [`translate(${hingeOffset.toFixed(3)}, 0)`];
         if (mirror) transforms.push('scale(-1,1)');
-        if (swingSign < 0) transforms.push('scale(1,-1)');
         const sweepFlag = swingSign > 0 ? 1 : 0;
         const lineAttrs = `stroke="${stroke}" stroke-width="${detailWidth.toFixed(3)}" vector-effect="non-scaling-stroke" stroke-linecap="round" stroke-linejoin="round"`;
         const dash = `${sheetMmToUnits(6).toFixed(3)} ${sheetMmToUnits(4).toFixed(3)}`;
@@ -1308,6 +1308,7 @@
         maskEl.setAttribute('id', baseId);
         maskEl.setAttribute('maskUnits', 'userSpaceOnUse');
         maskEl.setAttribute('maskContentUnits', 'userSpaceOnUse');
+        maskEl.setAttribute('mask-type', 'alpha');
         dom.defs?.appendChild(maskEl);
         entry = { id: baseId, mask: maskEl, openingsGroup };
         wallMaskMap.set(wallEl, entry);
@@ -2210,6 +2211,16 @@
         }
         renderGridLines();
     }
+
+    function updateFloorUnderlay() {
+        if (!state.viewBox || !dom.floorUnderlay) return;
+        const { x, y, width, height } = state.viewBox;
+        const margin = Math.max(state.gridSize || 0, Math.min(width, height) * 0.15);
+        dom.floorUnderlay.setAttribute('x', roundTo(x - margin, 3));
+        dom.floorUnderlay.setAttribute('y', roundTo(y - margin, 3));
+        dom.floorUnderlay.setAttribute('width', roundTo(width + margin * 2, 3));
+        dom.floorUnderlay.setAttribute('height', roundTo(height + margin * 2, 3));
+    }
     function applyGridPatternSize(sizePx) {
         if (!Number.isFinite(sizePx) || sizePx <= 0) return;
         const normalized = Math.round(sizePx * 1000) / 1000;
@@ -2308,6 +2319,7 @@
         if (!state.viewBox) return;
         dom.svg.setAttribute('viewBox', `${state.viewBox.x} ${state.viewBox.y} ${state.viewBox.width} ${state.viewBox.height}`);
         updateGridViewport();
+        updateFloorUnderlay();
         refreshWallStrokeWidths();
     }
     function startPan(e) {
@@ -3793,6 +3805,7 @@
             height: dom.svg.viewBox.baseVal.height
         };
 
+        updateFloorUnderlay();
         updateGridViewport();
         refreshWallStrokeWidths();
 

--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
                         <g id="grid-lines" aria-hidden="true"></g>
                     </g>
                     <g id="underlay-layer">
-                        <rect class="floor-underlay" x="0" y="0" width="100%" height="100%"></rect>
+                        <rect id="floor-underlay" class="floor-underlay" x="0" y="0" width="0" height="0"></rect>
                     </g>
                     <g id="walls-layer"></g>
                     <g id="openings-layer"></g>

--- a/templates.js
+++ b/templates.js
@@ -1256,10 +1256,15 @@ function buildRadiator({ width, depth }) {
 
 function buildPlant({ width }) {
   const radius = width / 2;
-  const leaf = `M 0 ${fmt(radius)} C ${fmt(radius * 0.6)} ${fmt(radius * 0.1)} ${fmt(radius * 0.6)} ${fmt(-radius * 0.4)} 0 ${fmt(-radius * 0.9)} C ${fmt(-radius * 0.6)} ${fmt(-radius * 0.4)} ${fmt(-radius * 0.6)} ${fmt(radius * 0.1)} 0 ${fmt(radius)} Z`;
+  const leafLength = radius * 0.95;
+  const leafWidth = radius * 0.55;
+  const leafPath = `M 0 ${fmt(leafLength)} C ${fmt(leafWidth)} ${fmt(leafLength * 0.45)} ${fmt(leafWidth)} ${fmt(-leafLength * 0.2)} 0 ${fmt(-leafLength * 0.8)} C ${fmt(-leafWidth)} ${fmt(-leafLength * 0.2)} ${fmt(-leafWidth)} ${fmt(leafLength * 0.45)} 0 ${fmt(leafLength)} Z`;
+  const rotations = [0, 90, 180, 270];
+  const leaves = rotations.map(angle => `<path d="${leafPath}" class="${CLASS_ACCENT}" transform="rotate(${fmt(angle)})"/>`).join('');
+  const veins = rotations.map(angle => `<line x1="0" y1="0" x2="0" y2="${fmt(leafLength * 0.7)}" class="${CLASS_DETAIL}" transform="rotate(${fmt(angle)})"/>`).join('');
   return join([
     circle(radius, { className: 'shape shape-fill' }),
-    path(leaf, CLASS_ACCENT)
+    `<g>${leaves}${veins}</g>`
   ]);
 }
 
@@ -1286,7 +1291,22 @@ function buildQueuePost({ width }) {
 }
 
 function buildMenuBoard({ width, depth }) {
-  return rect(width, depth, { className: 'shape shape-fill', radius: depth * 0.4 });
+  const frameRadius = depth * 0.45;
+  const panelWidth = width * 0.85;
+  const panelHeight = depth * 0.6;
+  const headerHeight = depth * 0.16;
+  const legInset = width * 0.15;
+  const legKneeY = depth * 0.72;
+  const baseY = depth / 2;
+  return join([
+    rect(width, depth, { className: 'shape shape-fill', radius: frameRadius }),
+    rect(panelWidth, panelHeight, { className: CLASS_ACCENT, y: -depth * 0.05 }),
+    rect(panelWidth * 0.6, headerHeight, { className: CLASS_DETAIL, y: -depth * 0.25 }),
+    line(-width / 2 + legInset, baseY, -width / 2 + legInset * 0.35, legKneeY, CLASS_DETAIL),
+    line(width / 2 - legInset, baseY, width / 2 - legInset * 0.35, legKneeY, CLASS_DETAIL),
+    line(-panelWidth * 0.35, depth * 0.05, panelWidth * 0.35, depth * 0.05, CLASS_DETAIL),
+    line(-panelWidth * 0.3, depth * 0.18, panelWidth * 0.3, depth * 0.18, CLASS_DETAIL)
+  ]);
 }
 
 function buildPlanter({ width, depth }) {


### PR DESCRIPTION
## Summary
- fix door swing rendering so inward and outward directions are visually distinct
- keep the green underlay anchored when zooming by syncing it with the SVG viewBox
- refresh schematic plant and menu board assets for clearer silhouettes

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d14c0905d08333842fe639cb413279