### PR TITLE
Keep floor background covering viewBox

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,6 +37,7 @@
         gridPattern: document.getElementById('grid'),
         gridRect: document.getElementById('grid-surface'),
         gridLinesGroup: document.getElementById('grid-lines'),
+        floorBackground: document.getElementById('floor-background'),
         floorUnderlay: document.getElementById('floor-underlay'),
         layersPanel: document.getElementById('layers-panel'),
         layersList: document.getElementById('layers-list'),
@@ -2212,6 +2213,15 @@
         renderGridLines();
     }
 
+    function updateFloorBackground() {
+        if (!state.viewBox || !dom.floorBackground) return;
+        const { x, y, width, height } = state.viewBox;
+        dom.floorBackground.setAttribute('x', roundTo(x, 3));
+        dom.floorBackground.setAttribute('y', roundTo(y, 3));
+        dom.floorBackground.setAttribute('width', roundTo(width, 3));
+        dom.floorBackground.setAttribute('height', roundTo(height, 3));
+    }
+
     function updateFloorUnderlay() {
         if (!state.viewBox || !dom.floorUnderlay) return;
         const { x, y, width, height } = state.viewBox;
@@ -2318,6 +2328,7 @@
     function updateViewBox() {
         if (!state.viewBox) return;
         dom.svg.setAttribute('viewBox', `${state.viewBox.x} ${state.viewBox.y} ${state.viewBox.width} ${state.viewBox.height}`);
+        updateFloorBackground();
         updateGridViewport();
         updateFloorUnderlay();
         refreshWallStrokeWidths();
@@ -3805,6 +3816,7 @@
             height: dom.svg.viewBox.baseVal.height
         };
 
+        updateFloorBackground();
         updateFloorUnderlay();
         updateGridViewport();
         refreshWallStrokeWidths();

--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
                             <path d="M0 0L10 5L0 10z" fill="#676D72" />
                         </marker>
                     </defs>
-                    <rect width="100%" height="100%" class="floor"/>
+                    <rect id="floor-background" width="100%" height="100%" class="floor"/>
                     <g id="grid-layer" pointer-events="none">
                         <rect id="grid-surface" width="100%" height="100%" fill="none" opacity="1"/>
                         <g id="grid-lines" aria-hidden="true"></g>


### PR DESCRIPTION
## Summary
- ensure the base floor rectangle is tracked in code so it follows viewBox adjustments
- update viewBox updates and initialization to resize the background with panning and zooming

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d187cd76b08333a7c35b741d6dbed4