### PR TITLE
Improve accessibility of properties panel

### DIFF
--- a/app.js
+++ b/app.js
@@ -829,7 +829,9 @@
         const inputs = [dom.propX, dom.propY, dom.propW, dom.propH, dom.propA];
         if (model && state.selectedObject) {
             dom.propControls.classList.remove('hidden');
+            dom.propControls?.removeAttribute('aria-hidden');
             dom.propPlaceholder.classList.add('hidden');
+            dom.propPlaceholder?.setAttribute('aria-hidden', 'true');
             const locked = !!model.locked;
             const width = Number.isFinite(model.ow) && Number.isFinite(model.sx) ? model.ow * model.sx : Number.NaN;
             const height = Number.isFinite(model.oh) && Number.isFinite(model.sy) ? model.oh * model.sy : Number.NaN;
@@ -846,7 +848,9 @@
             });
         } else {
             dom.propControls.classList.add('hidden');
+            dom.propControls?.setAttribute('aria-hidden', 'true');
             dom.propPlaceholder.classList.remove('hidden');
+            dom.propPlaceholder?.removeAttribute('aria-hidden');
             inputs.forEach(input => {
                 if (!input) return;
                 input.disabled = false;

--- a/index.html
+++ b/index.html
@@ -199,13 +199,19 @@
 
         <aside id="properties" aria-label="Свойства объекта">
             <h2>Свойства</h2>
-            <div id="prop-placeholder">Выделите объект</div>
-            <div id="prop-controls" class="hidden">
-                <label class="prop-label">X:</label><input type="number" id="prop-x" step="10">
-                <label class="prop-label">Y:</label><input type="number" id="prop-y" step="10">
-                <label class="prop-label">Ширина:</label><input type="number" id="prop-w" step="10" min="1">
-                <label class="prop-label">Высота:</label><input type="number" id="prop-h" step="10" min="1">
-                <label class="prop-label">Поворот:</label><input type="number" id="prop-a" step="15" min="-360" max="360">
+            <div id="prop-placeholder" role="status" aria-live="polite">Выделите объект</div>
+            <div
+                id="prop-controls"
+                class="hidden"
+                role="group"
+                aria-label="Геометрические параметры"
+                aria-hidden="true"
+            >
+                <label class="prop-label" for="prop-x">X:</label><input type="number" id="prop-x" step="10">
+                <label class="prop-label" for="prop-y">Y:</label><input type="number" id="prop-y" step="10">
+                <label class="prop-label" for="prop-w">Ширина:</label><input type="number" id="prop-w" step="10" min="1">
+                <label class="prop-label" for="prop-h">Высота:</label><input type="number" id="prop-h" step="10" min="1">
+                <label class="prop-label" for="prop-a">Поворот:</label><input type="number" id="prop-a" step="15" min="-360" max="360">
             </div>
 
             <section id="component-panel" class="panel hidden" aria-label="Свойства проёма">


### PR DESCRIPTION
## Summary
- add explicit labelling and accessibility roles to the object properties controls
- synchronise aria-hidden state when toggling between the placeholder and editable inputs

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3a8fd15508333a9ac57ffa925e893